### PR TITLE
Handle the ObjectDisposedException which always occurs when disposing

### DIFF
--- a/Transport/BACnetTransport.cs
+++ b/Transport/BACnetTransport.cs
@@ -154,9 +154,9 @@ namespace System.IO.BACnet
                     localBuffer = conn.EndReceive(asyncResult, ref ep);
                     rx = localBuffer.Length;
                 }
-                catch (Exception ex) // ICMP port unreachable
+                catch (Exception) // ICMP port unreachable
                 {
-                    if (!(ex is ObjectDisposedException && _disposing)) // do not restart data receive when disposing
+                    if (!_disposing) // do not restart data receive when disposing
                     {
                         //restart data receive
                         conn.BeginReceive(OnReceiveData, conn);


### PR DESCRIPTION
My application crashes on this exception. The weird thing, actually, is that it doesn't always crash (while the exception always occurs). Couldn't figure out in what situation it does, but handling the exception fixed the crashing.