### PR TITLE
Perform APDU retries only on timeout.

### DIFF
--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BacnetAsyncResult.cs" />
+    <Compile Include="BacnetException.cs" />
     <Compile Include="Base\BacnetAbortReason.cs" />
     <Compile Include="Base\BacnetAddress.cs" />
     <Compile Include="Base\BacnetAddressTypes.cs" />

--- a/BacnetException.cs
+++ b/BacnetException.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System.IO.BACnet
+{
+    public class BacnetException : Exception
+    {
+        public BacnetException()
+        {
+        }
+
+        public BacnetException(string message)
+        : base(message)
+        {
+        }
+
+        public BacnetException(string message, Exception inner)
+        : base(message, inner)
+        {
+        }
+    }
+
+    public class BacnetApduTimeoutException : BacnetException
+    {
+        public BacnetApduTimeoutException(string message)
+        : base(message)
+        {
+        }
+    }
+
+    public class BacnetErrorException : BacnetException
+    {
+        public BacnetErrorClasses ErrorClass { get; }
+        public BacnetErrorCodes ErrorCode { get; }
+
+        public BacnetErrorException(BacnetErrorClasses errorClass, BacnetErrorCodes errorCode)
+         : base($"Error from device: {errorClass} - {errorCode}")
+        {
+            ErrorClass = errorClass;
+            ErrorCode = errorCode;
+        }
+    }
+
+    public class BacnetAbortException : BacnetException
+    {
+        public BacnetAbortReason Reason { get; }
+        public BacnetErrorCodes ErrorCode { get; }
+
+        public BacnetAbortException(BacnetAbortReason reason)
+        : base($"Abort from device, reason: {reason}")
+        {
+            Reason = reason;
+        }
+    }
+
+    public class BacnetRejectException : BacnetException
+    {
+        public BacnetRejectReason Reason { get; }
+        public BacnetErrorCodes ErrorCode { get; }
+
+        public BacnetRejectException(BacnetRejectReason reason)
+        : base($"Reject from device, reason: {reason}")
+        {
+            Reason = reason;
+        }
+    }
+}


### PR DESCRIPTION
This commit made it so that we do not resend an APDU when the operation has failed (WRITE_ACCESS_DENIED on WriteProperty, ABORT errors etc) since the is little to no chance that the situation will have resolved itself in between the retries.