### PR TITLE
Use socketoptions to make udp work with non-windows platforms

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -78,9 +78,9 @@ namespace System.IO.BACnet
                 {
                     _sharedConn = new UdpClient { ExclusiveAddressUse = false };
                     _sharedConn.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    _sharedConn.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                     var ep = new IPEndPoint(IPAddress.Any, SharedPort);
                     if (!string.IsNullOrEmpty(_localEndpoint)) ep = new IPEndPoint(IPAddress.Parse(_localEndpoint), SharedPort);
-                    DisableConnReset(_sharedConn);
                     _sharedConn.Client.Bind(ep);
                     _sharedConn.DontFragment = _dontFragment;
                     Log.Info($"Binded shared {ep} using UDP");
@@ -92,7 +92,6 @@ namespace System.IO.BACnet
                     var ep = new IPEndPoint(IPAddress.Any, ExclusivePort);
                     if (!string.IsNullOrEmpty(_localEndpoint)) ep = new IPEndPoint(IPAddress.Parse(_localEndpoint), ExclusivePort);
                     _exclusiveConn = new UdpClient(ep);
-
                     // Gets the Endpoint : the assigned Udp port number in fact
                     ep = (IPEndPoint) _exclusiveConn.Client.LocalEndPoint;
                     // closes the socket
@@ -106,7 +105,7 @@ namespace System.IO.BACnet
                         EnableBroadcast = true
                     };
 
-                    DisableConnReset(_exclusiveConn);
+                    _exclusiveConn.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 }
             }
             else
@@ -114,7 +113,7 @@ namespace System.IO.BACnet
                 var ep = new IPEndPoint(IPAddress.Any, SharedPort);
                 if (!string.IsNullOrEmpty(_localEndpoint)) ep = new IPEndPoint(IPAddress.Parse(_localEndpoint), SharedPort);
                 _exclusiveConn = new UdpClient { ExclusiveAddressUse = true };
-                DisableConnReset(_exclusiveConn);
+                _exclusiveConn.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
                 _exclusiveConn.Client.Bind(ep);
                 _exclusiveConn.DontFragment = _dontFragment;
                 _exclusiveConn.EnableBroadcast = true;
@@ -122,22 +121,6 @@ namespace System.IO.BACnet
             }
 
             Bvlc = new BVLC(this);
-        }
-
-        /// <summary>
-        ///   Done to prevent exceptions in Socket.BeginReceive()
-        /// </summary>
-        /// <remarks>
-        ///   http://microsoft.public.win32.programmer.networks.narkive.com/RlxW2V6m/udp-comms-and-connection-reset-problem
-        /// </remarks>
-        private static void DisableConnReset(UdpClient client)
-        {
-            const uint IOC_IN = 0x80000000;
-            const uint IOC_VENDOR = 0x18000000;
-            const uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
-
-            client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
-                new[] { System.Convert.ToByte(false) }, null);
         }
 
         protected void Close()


### PR DESCRIPTION
Hello,

I am interested in using this library on linux, unfortunately the netstandard project did not work out of the box. 

Function in DisableConnReset was giving PlatformNotSupported exception. I was able to find discussion [here](https://github.com/dotnet/runtime/issues/25555) which would suggest that SocketOptions is the multiplatform version of this. Now it does not throw exceptions anymore.