### PR TITLE
Miscellaneous change requests

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -353,6 +353,7 @@ namespace System.IO.BACnet
                 }
                 else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL && OnDeviceCommunicationControl != null)
                 {
+                    // DAL
                     if (Services.DecodeDeviceCommunicationControl(buffer, offset, length, out var timeDuration, out var enableDisable, out var password) >= 0)
                         OnDeviceCommunicationControl(this, address, invokeId, timeDuration, enableDisable, password, maxSegments);
                     else
@@ -365,6 +366,7 @@ namespace System.IO.BACnet
                 }
                 else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_REINITIALIZE_DEVICE && OnReinitializedDevice != null)
                 {
+                    // DAL
                     if (Services.DecodeReinitializeDevice(buffer, offset, length, out var state, out var password) >= 0)
                         OnReinitializedDevice(this, address, invokeId, state, password, maxSegments);
                     else
@@ -395,7 +397,7 @@ namespace System.IO.BACnet
                         OnReadRange(this, address, invokeId, objectId, property, requestType, position, time, count, maxSegments);
                     else
                     {
-                                                // DAL
+                        // DAL
                         SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                         //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode ReadRange");
@@ -427,7 +429,10 @@ namespace System.IO.BACnet
                 }
                 else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_GET_ALARM_SUMMARY && OnGetAlarmSummaryOrEventInformation != null)
                 {
-                    // DAL
+                    // DAL -- added the core code required but since I couldn't test it we just reject this service
+                    // rejecting it shouldn't be too bad a thing since GetAlarmSummary has been retired anyway...
+                    // if someone needs it they can uncomment the related code and test.
+#if false
                     BacnetObjectId objectId = default(BacnetObjectId);
                     objectId.Type = BacnetObjectTypes.MAX_BACNET_OBJECT_TYPE;
                     if (Services.DecodeAlarmSummaryOrEventRequest(buffer, offset, length, false, ref objectId) >= 0)
@@ -441,6 +446,9 @@ namespace System.IO.BACnet
                         //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode GetAlarmSummary");
                     }
+#else
+                    SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
+#endif
                 }
                 else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_GET_EVENT_INFORMATION && OnGetAlarmSummaryOrEventInformation != null)
                 {

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1326,7 +1326,7 @@ namespace System.IO.BACnet
 
             //encode
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
-            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource);
+            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_ATOMIC_READ_FILE, MaxSegments, Transport.MaxAdpuLength, invokeId);
             Services.EncodeAtomicReadFile(buffer, true, objectId, position, count);
 
@@ -1407,7 +1407,7 @@ namespace System.IO.BACnet
 
             //encode
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
-            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource);
+            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_READ_RANGE, MaxSegments, Transport.MaxAdpuLength, invokeId);
             Services.EncodeReadRange(buffer, objectId, (uint)BacnetPropertyIds.PROP_LOG_BUFFER, ASN1.BACNET_ARRAY_ALL, bacnetReadRangeRequestTypes, idxBegin, readFrom, (int)quantity);
             //send
@@ -1512,7 +1512,7 @@ namespace System.IO.BACnet
                 invokeId = unchecked(_invokeId++);
 
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
-            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource);
+            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_SUBSCRIBE_COV, MaxSegments, Transport.MaxAdpuLength, invokeId);
             Services.EncodeSubscribeCOV(buffer, subscribeId, objectId, cancel, issueConfirmedNotifications, lifetime);
 
@@ -1532,6 +1532,8 @@ namespace System.IO.BACnet
 
             res.Dispose();
         }
+
+        // DAL
         public bool SendConfirmedEventNotificationRequest(BacnetAddress adr, BacnetEventNotificationData eventData, byte invokeId = 0, BacnetAddress source = null)
         {
             using (var result = (BacnetAsyncResult)BeginSendConfirmedEventNotificationRequest(adr, eventData, true, invokeId, source))
@@ -1552,6 +1554,7 @@ namespace System.IO.BACnet
             return false;
         }
 
+        // DAL
         public IAsyncResult BeginSendConfirmedEventNotificationRequest(BacnetAddress adr, BacnetEventNotificationData eventData, bool waitForTransmit, byte invokeId = 0, BacnetAddress source = null)
         {
             Log.Debug($"Sending Confirmed Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
@@ -1559,7 +1562,7 @@ namespace System.IO.BACnet
                 invokeId = unchecked(_invokeId++);
 
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
-            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource);
+            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr, source);
             APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_EVENT_NOTIFICATION, MaxSegments, Transport.MaxAdpuLength, invokeId);
             Services.EncodeEventNotifyConfirmed(buffer, eventData);
 
@@ -1570,6 +1573,7 @@ namespace System.IO.BACnet
             return ret;
         }
 
+        // DAL
         public void EndSendConfirmedEventNotificationRequest(IAsyncResult result, out Exception ex)
         {
             var res = (BacnetAsyncResult)result;
@@ -1607,7 +1611,7 @@ namespace System.IO.BACnet
                 invokeId = unchecked(_invokeId++);
 
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
-            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource);
+            NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_SUBSCRIBE_COV_PROPERTY, MaxSegments, Transport.MaxAdpuLength, invokeId);
             Services.EncodeSubscribeProperty(buffer, subscribeId, objectId, cancel, issueConfirmedNotifications, 0, monitoredProperty, false, 0f);
 

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -260,7 +260,9 @@ namespace System.IO.BACnet
                         OnWritePropertyRequest(this, address, invokeId, objectId, value, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         //SendConfirmedServiceReject(adr, invokeId, BacnetRejectReason.OTHER); 
                         Log.Warn("Couldn't decode DecodeWriteProperty");
                     }
@@ -271,7 +273,9 @@ namespace System.IO.BACnet
                         OnReadPropertyMultipleRequest(this, address, invokeId, properties, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode DecodeReadPropertyMultiple");
                     }
                 }
@@ -281,7 +285,9 @@ namespace System.IO.BACnet
                         OnWritePropertyMultipleRequest(this, address, invokeId, objectId, values, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode DecodeWritePropertyMultiple");
                     }
                 }
@@ -291,7 +297,9 @@ namespace System.IO.BACnet
                         OnCOVNotification(this, address, invokeId, subscriberProcessIdentifier, initiatingDeviceIdentifier, monitoredObjectIdentifier, timeRemaining, true, values, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode COVNotify");
                     }
                 }
@@ -301,7 +309,9 @@ namespace System.IO.BACnet
                         OnAtomicWriteFileRequest(this, address, invokeId, isStream, objectId, position, blockCount, blocks, counts, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode AtomicWriteFile");
                     }
                 }
@@ -311,7 +321,9 @@ namespace System.IO.BACnet
                         OnAtomicReadFileRequest(this, address, invokeId, isStream, objectId, position, count, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode AtomicReadFile");
                     }
                 }
@@ -321,7 +333,9 @@ namespace System.IO.BACnet
                         OnSubscribeCOV(this, address, invokeId, subscriberProcessIdentifier, monitoredObjectIdentifier, cancellationRequest, issueConfirmedNotifications, lifetime, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode SubscribeCOV");
                     }
                 }
@@ -331,7 +345,9 @@ namespace System.IO.BACnet
                         OnSubscribeCOVProperty(this, address, invokeId, subscriberProcessIdentifier, monitoredObjectIdentifier, monitoredProperty, cancellationRequest, issueConfirmedNotifications, lifetime, covIncrement, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode SubscribeCOVProperty");
                     }
                 }
@@ -341,7 +357,9 @@ namespace System.IO.BACnet
                         OnDeviceCommunicationControl(this, address, invokeId, timeDuration, enableDisable, password, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode DeviceCommunicationControl");
                     }
                 }
@@ -351,7 +369,9 @@ namespace System.IO.BACnet
                         OnReinitializedDevice(this, address, invokeId, state, password, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode ReinitializeDevice");
                     }
                 }
@@ -363,7 +383,9 @@ namespace System.IO.BACnet
                     }
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode Event/Alarm Notification");
                     }
                 }
@@ -373,7 +395,9 @@ namespace System.IO.BACnet
                         OnReadRange(this, address, invokeId, objectId, property, requestType, position, time, count, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                                                // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode ReadRange");
                     }
                 }
@@ -383,7 +407,9 @@ namespace System.IO.BACnet
                         OnCreateObjectRequest(this, address, invokeId, objectId, values, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode CreateObject");
                     }
                 }
@@ -393,7 +419,9 @@ namespace System.IO.BACnet
                         OnDeleteObjectRequest(this, address, invokeId, objectId, maxSegments);
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode DecodeDeleteObject");
                     }
                 }
@@ -408,7 +436,9 @@ namespace System.IO.BACnet
                     }
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode GetAlarmSummary");
                     }
                 }
@@ -423,7 +453,9 @@ namespace System.IO.BACnet
                     }
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode GetEventInformation");
                     }
                 }
@@ -436,19 +468,24 @@ namespace System.IO.BACnet
                     }
                     else
                     {
-                        ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                        // DAL
+                        SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                        //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                         Log.Warn("Couldn't decode AlarmAcknowledge");
                     }
                 }
                 else
                 {
-                    ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_REJECT_UNRECOGNIZED_SERVICE);
+                    // DAL
+                    SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
                     Log.Warn($"Confirmed service not handled: {service}");
                 }
             }
             catch (Exception ex)
             {
-                ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_DEVICE, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
+                // DAL
+                SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_DEVICE, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                 Log.Error("Error in ProcessConfirmedServiceRequest", ex);
             }
         }
@@ -1128,14 +1165,26 @@ namespace System.IO.BACnet
             Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
         }
 
-        public void SendConfirmedServiceReject(BacnetAddress adr, byte invokeId, BacnetRejectReason reason, BacnetAddress source = null)
+        public void SendConfirmedServiceReject(BacnetAddress adr, byte invokeId, BacnetRejectReason reason)
         {
             Log.Debug($"Sending Service reject: {reason}");
 
             var b = GetEncodeBuffer(Transport.HeaderLength);
 
-            NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
+            NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeError(b, BacnetPduTypes.PDU_TYPE_REJECT, (BacnetConfirmedServices)reason, invokeId);
+            Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
+        }
+
+        public void SendAbort(BacnetAddress adr, byte invokeId, BacnetAbortReason reason)
+        {
+            // DAL
+            Log.Debug($"Sending Service reject: {reason}");
+
+            var b = GetEncodeBuffer(Transport.HeaderLength);
+
+            NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
+            APDU.EncodeError(b, BacnetPduTypes.PDU_TYPE_ABORT, (BacnetConfirmedServices)reason, invokeId);
             Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
         }
 
@@ -2310,17 +2359,18 @@ namespace System.IO.BACnet
             res.Dispose();
         }
         // DAL
-        // the reason for making more_events nullable is on the off chance that some day someone needs to 
-        // support the old GetAlarmSummary responses.   Then they can just set more_events to null to 
-        // signify that is what should be used without breaking the api.
-        public void GetEventInformationResponse(BacnetAddress adr, byte invoke_id, Segmentation segmentation, BacnetGetEventInformationData[] data, bool? more_events)
+        public void GetEventInformationResponse(BacnetAddress adr, bool getEvent, byte invoke_id, Segmentation segmentation, BacnetGetEventInformationData[] data, bool more_events)
         {
+            // 'getEvent' is not currently used.   Can be used if ever implementing GetAlarmSummary.
             // response could be segmented
+            // but if you don't want it segmented (which would be normal usage)
+            // you have to compute the message data and the 'more' flag
+            // outside this function.
             HandleSegmentationResponse(adr, invoke_id, segmentation, (o) =>
             {
                 SendComplexAck(adr, invoke_id, segmentation, BacnetConfirmedServices.SERVICE_CONFIRMED_GET_EVENT_INFORMATION, (b) =>
                 {
-                    Services.EncodeGetEventInformationAcknowledge(b, data, more_events.Value);
+                    Services.EncodeGetEventInformationAcknowledge(b, data, more_events);
                 });
             });
         }
@@ -2701,7 +2751,9 @@ namespace System.IO.BACnet
                 if (segmentation == null)
                 {
                     Log.Info("Segmenation denied");
-                    ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
+                    // DAL
+                    SendAbort(adr, invokeId, BacnetAbortReason.APDU_TOO_LONG);
+                    //ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
                     buffer.result = EncodeResult.Good;     //don't continue the segmentation
                     return;
                 }
@@ -2712,7 +2764,9 @@ namespace System.IO.BACnet
                     if (segmentation.max_segments != 0xFF && segmentation.buffer.offset > segmentation.max_segments * (GetMaxApdu() - 5))      //5 is adpu header
                     {
                         Log.Info("Too much segmenation");
-                        ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
+                        // DAL
+                        SendAbort(adr, invokeId, BacnetAbortReason.APDU_TOO_LONG);
+                        //ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
                         buffer.result = EncodeResult.Good;     //don't continue the segmentation
                         return;
                     }

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -882,7 +882,7 @@ namespace System.IO.BACnet
         }
 
         // DAL
-        public void SendNetworkMessage(BacnetAddress adr, byte[] buffer, int bufLen, BacnetNetworkMessageTypes messageType, ushort vendorId)
+        public void SendNetworkMessage(BacnetAddress adr, byte[] buffer, int bufLen, BacnetNetworkMessageTypes messageType, ushort vendorId = 0)
         {
             if (adr == null)
             {
@@ -893,17 +893,17 @@ namespace System.IO.BACnet
             b.Add(buffer, bufLen);
             Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
         }
-        public void SendIAmRouterToNetwork(ushort[] networks, ushort vendorId)
+        public void SendIAmRouterToNetwork(ushort[] networks)
         {
             var b = GetEncodeBuffer(0);
             for (int i = 0; i < networks.Length; i++)
             {
                 ASN1.encode_unsigned16(b, networks[i]);
             }
-            SendNetworkMessage(null, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_I_AM_ROUTER_TO_NETWORK, vendorId);
+            SendNetworkMessage(null, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_I_AM_ROUTER_TO_NETWORK);
         }
 
-        public void SendInitializeRoutingTableAck(BacnetAddress adr, ushort[] networks, ushort vendorId)
+        public void SendInitializeRoutingTableAck(BacnetAddress adr, ushort[] networks)
         {
             var b = GetEncodeBuffer(0);
             if (networks != null)
@@ -913,9 +913,9 @@ namespace System.IO.BACnet
                     ASN1.encode_unsigned16(b, networks[i]);
                 }
             }
-            SendNetworkMessage(adr, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_INIT_RT_TABLE_ACK, vendorId);
+            SendNetworkMessage(adr, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_INIT_RT_TABLE_ACK);
         }
-        public void SendRejectToNetwork(BacnetAddress adr, ushort[] networks, ushort vendorId)
+        public void SendRejectToNetwork(BacnetAddress adr, ushort[] networks)
         {
             var b = GetEncodeBuffer(0);
             /* Sending our DNET doesn't make a lot of sense, does it? */
@@ -923,7 +923,7 @@ namespace System.IO.BACnet
             {
                 ASN1.encode_unsigned16(b, networks[i]);
             }
-            SendNetworkMessage(adr, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_REJECT_MESSAGE_TO_NETWORK, vendorId);
+            SendNetworkMessage(adr, b.buffer, b.offset, BacnetNetworkMessageTypes.NETWORK_MESSAGE_REJECT_MESSAGE_TO_NETWORK);
         }
         public delegate void NetworkMessageHandler(BacnetClient sender, BacnetAddress adr, BacnetNpduControls npduFunction, BacnetNetworkMessageTypes npduMessageType, byte[] buffer, int offset, int messageLength);
         public event NetworkMessageHandler OnNetworkMessage;
@@ -1152,7 +1152,7 @@ namespace System.IO.BACnet
         }
 
         // ReSharper disable once InconsistentNaming
-        public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source)
+        public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source = null)
         {
             Log.Debug($"Broadcasting IHave {objName} {objId}");
 

--- a/Base/BacnetAddress.cs
+++ b/Base/BacnetAddress.cs
@@ -15,6 +15,9 @@ namespace System.IO.BACnet
         // Modif FC
         public BacnetAddress RoutedSource = null;
 
+        // DAL
+        public BacnetAddress RoutedDestination = null;
+
         public BacnetAddress(BacnetAddressTypes addressType, ushort network = 0, byte[] address = null)
         {
             type = addressType;

--- a/Base/BacnetAddress.cs
+++ b/Base/BacnetAddress.cs
@@ -60,7 +60,9 @@ namespace System.IO.BACnet
 
         public override int GetHashCode()
         {
-            return adr.GetHashCode();
+            // DAL this was originally broken...
+            var str = Convert.ToBase64String(adr);
+            return str.GetHashCode();
         }
 
         public override string ToString()
@@ -151,10 +153,17 @@ namespace System.IO.BACnet
             if (RoutedSource == null && d.RoutedSource != null)
                 return false;
 
-            if (d.RoutedSource==null&&RoutedSource == null)
-                return true;
+            // DAL
+            if (RoutedDestination == null && d.RoutedDestination != null)
+                return false;
 
-            return RoutedSource?.Equals(d.RoutedSource) ?? false;
+            if (d.RoutedSource==null&&RoutedSource == null &&
+                d.RoutedDestination == null && RoutedDestination == null)
+                    return true;
+
+            bool rv = RoutedSource?.Equals(d.RoutedSource) ?? false;
+            rv |= RoutedDestination?.Equals(d.RoutedDestination) ?? false;
+            return rv;
         }
 
         // checked if device is routed by curent equipement
@@ -183,6 +192,9 @@ namespace System.IO.BACnet
 
             if (RoutedSource != null)
                 hash += $":{RoutedSource.FullHashString()}";
+
+            if (RoutedDestination != null)
+                hash += $":{RoutedDestination.FullHashString()}";
 
             return hash;
         }

--- a/Base/DeviceReportingRecipient.cs
+++ b/Base/DeviceReportingRecipient.cs
@@ -14,6 +14,9 @@ namespace System.IO.BACnet
         public bool Ack_Required;
         public BacnetBitString evenType;
 
+        // DAL - i didn't change the constructors since it would have been an API break
+        public bool confirmedNotify;
+
         public DeviceReportingRecipient(BacnetValue v0, BacnetValue v1, BacnetValue v2, BacnetValue v3, BacnetValue v4, BacnetValue v5, BacnetValue v6)
         {
             Id = new BacnetObjectId();
@@ -36,6 +39,7 @@ namespace System.IO.BACnet
             processIdentifier = (uint)v4.Value;
             Ack_Required = (bool)v5.Value;
             evenType = (BacnetBitString)v6.Value;
+            confirmedNotify = false;
         }
 
         public DeviceReportingRecipient(BacnetBitString weekofDay, DateTime fromTime, DateTime toTime, BacnetObjectId id, uint processIdentifier, bool ackRequired, BacnetBitString evenType)
@@ -49,6 +53,7 @@ namespace System.IO.BACnet
             this.processIdentifier = processIdentifier;
             Ack_Required = ackRequired;
             this.evenType = evenType;
+            confirmedNotify = false;
         }
 
         public DeviceReportingRecipient(BacnetBitString weekofDay, DateTime fromTime, DateTime toTime, BacnetAddress adr, uint processIdentifier, bool ackRequired, BacnetBitString evenType)
@@ -61,6 +66,7 @@ namespace System.IO.BACnet
             this.processIdentifier = processIdentifier;
             Ack_Required = ackRequired;
             this.evenType = evenType;
+            confirmedNotify = false;
         }
 
         public void Encode(EncodeBuffer buffer)

--- a/Base/DeviceReportingRecipient.cs
+++ b/Base/DeviceReportingRecipient.cs
@@ -14,9 +14,6 @@ namespace System.IO.BACnet
         public bool Ack_Required;
         public BacnetBitString evenType;
 
-        // DAL - i didn't change the constructors since it would have been an API break
-        public bool confirmedNotify;
-
         public DeviceReportingRecipient(BacnetValue v0, BacnetValue v1, BacnetValue v2, BacnetValue v3, BacnetValue v4, BacnetValue v5, BacnetValue v6)
         {
             Id = new BacnetObjectId();
@@ -39,7 +36,6 @@ namespace System.IO.BACnet
             processIdentifier = (uint)v4.Value;
             Ack_Required = (bool)v5.Value;
             evenType = (BacnetBitString)v6.Value;
-            confirmedNotify = false;
         }
 
         public DeviceReportingRecipient(BacnetBitString weekofDay, DateTime fromTime, DateTime toTime, BacnetObjectId id, uint processIdentifier, bool ackRequired, BacnetBitString evenType)
@@ -53,7 +49,6 @@ namespace System.IO.BACnet
             this.processIdentifier = processIdentifier;
             Ack_Required = ackRequired;
             this.evenType = evenType;
-            confirmedNotify = false;
         }
 
         public DeviceReportingRecipient(BacnetBitString weekofDay, DateTime fromTime, DateTime toTime, BacnetAddress adr, uint processIdentifier, bool ackRequired, BacnetBitString evenType)
@@ -66,7 +61,6 @@ namespace System.IO.BACnet
             this.processIdentifier = processIdentifier;
             Ack_Required = ackRequired;
             this.evenType = evenType;
-            confirmedNotify = false;
         }
 
         public void Encode(EncodeBuffer buffer)

--- a/Serialize/NPDU.cs
+++ b/Serialize/NPDU.cs
@@ -118,14 +118,15 @@
                 buffer.buffer[buffer.offset++] = (byte)((source.net & 0xFF00) >> 8);
                 buffer.buffer[buffer.offset++] = (byte)((source.net & 0x00FF) >> 0);
                 // Modif FC
-                if (destination.net == 0xFFFF)
+                // DAL this used to encode the destination address, which is clearly wrong...
+                if (source.net == 0xFFFF)
                     buffer.buffer[buffer.offset++] = 0;
                 else
                 {
-                    buffer.buffer[buffer.offset++] = (byte)destination.adr.Length;
-                    if (destination.adr.Length > 0)
+                    buffer.buffer[buffer.offset++] = (byte)source.adr.Length;
+                    if (source.adr.Length > 0)
                     {
-                        foreach (var t in destination.adr)
+                        foreach (var t in source.adr)
                             buffer.buffer[buffer.offset++] = t;
                     }
                 }

--- a/Serialize/NPDU.cs
+++ b/Serialize/NPDU.cs
@@ -59,8 +59,9 @@
                 {
                     vendorId = (ushort)((buffer[offset++] << 8) | (buffer[offset++] << 0));
                 }
-                else if (networkMsgType == BacnetNetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK)
-                    offset += 2;  // Don't care about destination network adress
+                //DAL
+//                else if (networkMsgType == BacnetNetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK)
+//                    offset += 2;  // Don't care about destination network adress
             }
 
             if (buffer[orgOffset + 0] != BACNET_PROTOCOL_VERSION)

--- a/Serialize/NPDU.cs
+++ b/Serialize/NPDU.cs
@@ -118,18 +118,11 @@
             {
                 buffer.buffer[buffer.offset++] = (byte)((source.net & 0xFF00) >> 8);
                 buffer.buffer[buffer.offset++] = (byte)((source.net & 0x00FF) >> 0);
-                // Modif FC
-                // DAL this used to encode the destination address, which is clearly wrong...
-                if (source.net == 0xFFFF)
-                    buffer.buffer[buffer.offset++] = 0;
-                else
+                buffer.buffer[buffer.offset++] = (byte)source.adr.Length;
+                if (source.adr.Length > 0)
                 {
-                    buffer.buffer[buffer.offset++] = (byte)source.adr.Length;
-                    if (source.adr.Length > 0)
-                    {
-                        foreach (var t in source.adr)
-                            buffer.buffer[buffer.offset++] = t;
-                    }
+                    foreach (var t in source.adr)
+                        buffer.buffer[buffer.offset++] = t;
                 }
             }
 

--- a/Serialize/NPDU.cs
+++ b/Serialize/NPDU.cs
@@ -59,7 +59,7 @@
                 {
                     vendorId = (ushort)((buffer[offset++] << 8) | (buffer[offset++] << 0));
                 }
-                //DAL
+                //DAL - this originally made no sense as the higher level code would just ignore network messages
 //                else if (networkMsgType == BacnetNetworkMessageTypes.NETWORK_MESSAGE_WHO_IS_ROUTER_TO_NETWORK)
 //                    offset += 2;  // Don't care about destination network adress
             }

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -1166,7 +1166,7 @@ namespace System.IO.BACnet.Serialize
             EncodeEventNotifyData(buffer, data);
         }
 
-		public static void EncodeAlarmSummary(EncodeBuffer buffer, BacnetObjectId objectIdentifier, uint alarmState, BacnetBitString acknowledgedTransitions)
+        public static void EncodeAlarmSummary(EncodeBuffer buffer, BacnetObjectId objectIdentifier, uint alarmState, BacnetBitString acknowledgedTransitions)
         {
             /* tag 0 - Object Identifier */
             ASN1.encode_application_object_id(buffer, objectIdentifier.type, objectIdentifier.instance);

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -1166,6 +1166,15 @@ namespace System.IO.BACnet.Serialize
             EncodeEventNotifyData(buffer, data);
         }
 
+		public static void EncodeAlarmSummary(EncodeBuffer buffer, BacnetObjectId objectIdentifier, uint alarmState, BacnetBitString acknowledgedTransitions)
+        {
+            /* tag 0 - Object Identifier */
+            ASN1.encode_application_object_id(buffer, objectIdentifier.type, objectIdentifier.instance);
+            /* tag 1 - Alarm State */
+            ASN1.encode_application_enumerated(buffer, alarmState);
+            /* tag 2 - Acknowledged Transitions */
+            ASN1.encode_application_bitstring(buffer, acknowledgedTransitions);
+        }
 
         // FChaxel
         public static int DecodeAlarmSummaryOrEvent(byte[] buffer, int offset, int apduLen, bool getEvent, ref IList<BacnetGetEventInformationData> alarms, out bool moreEvent)

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -211,25 +211,25 @@ namespace System.IO.BACnet.Serialize
             len += ASN1.decode_context_enumerated(buffer, offset + len, 2, out eventStateAcked);
             if (ASN1.decode_is_context_tag(buffer, offset + len, 3))
             {
-                len += 1; // opening Tag 3
+                len += 2; // opening Tag 3 then 2
                 len += ASN1.decode_application_date(buffer, offset + len, out var date);
                 len += ASN1.decode_application_time(buffer, offset + len, out var time);
                 eventTimeStamp.Time = new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute,
                     time.Second, time.Millisecond);
 
-                len += 1; // closing tag 3
+                len += 2; // closing tag 2 then 3
             }
             else
                 return -1;
             len += ASN1.decode_context_character_string(buffer, offset + len, 256, 4, out ackSource);
             if (ASN1.decode_is_context_tag(buffer, offset + len, 5))
             {
-                len += 1; // opening Tag 5
+                len += 2; // opening Tag 5 then 2
                 len += ASN1.decode_application_date(buffer, offset + len, out var date);
                 len += ASN1.decode_application_time(buffer, offset + len, out var time);
                 ackTimeStamp.Time = new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute,
                     time.Second, time.Millisecond);
-                len += 1; // closing tag 5
+                len += 2; // closing tag 2 then 5
             }
             else
                 return -1;


### PR DESCRIPTION
Changes are as follows:

add function to send aborts and change aborts from error messages to actual aborts
change a couple of rejects from error messages to actual rejects
make a version of GetMaxAPDU that can calculate the max apdu from incoming service request header fields.   Only used for GetEventInformation processing right now.
change the abort code when segmentation is not being used and a segmented message would be required:  Should be SEGMENTATION_NOT_SUPPORTED

add a decoder for CONFIRMED_ALARM_ACKNOWLEDGE service requests
add a decoder for CONFIRMED_GET_EVENT_INFORMATION service requests

parse device communication control incoming service and add callback
parse reinitialize device incoming service and add callback
parse geteventinformation incoming service and add callback
parse alarm acknowledge incoming service and add callback

add function to send 'response' to be used with incoming GetEventInformation requests.
add function to send a confirmed event notification.

add support for parsing and callbacks for network layer messages
add a low level network message sender and some basic send functions such as for I_AM_ROUTER_TO_NETWORK

add a RoutedDestination to the bacnet address similar to the routed source.   Add support throughout for using it in the 'source' field of replies or of generated messages.   Intended to be used for one IP address routing multiple devices.
fix the BacnetAddress GetHashCodeFunction to return a stable hash code

change NPDU.Decode to not know about specific message type WHO_IS_ROUTER_TO_NETWORK
change NPDU.Encode to encode the source address properly

