### PR TITLE
Use socketoptions to make udp work with non-windows platforms

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -167,10 +167,6 @@ namespace System.IO.BACnet
                 client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
                     new[] { System.Convert.ToByte(false) }, null);
             }
-            else
-            {
-                client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
-            }
         }
 
         protected void Close()

--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -158,12 +158,19 @@ namespace System.IO.BACnet
         /// </remarks>
         private static void DisableConnReset(UdpClient client)
         {
-            const uint IOC_IN = 0x80000000;
-            const uint IOC_VENDOR = 0x18000000;
-            const uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                const uint IOC_IN = 0x80000000;
+                const uint IOC_VENDOR = 0x18000000;
+                const uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
 
-            client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
-                new[] { System.Convert.ToByte(false) }, null);
+                client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
+                    new[] { System.Convert.ToByte(false) }, null);
+            }
+            else
+            {
+                client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            }
         }
 
         protected void Close()


### PR DESCRIPTION
Hello,

Function in DisableConnReset was giving PlatformNotSupported exception. I was able to find discussion [here](https://github.com/dotnet/runtime/issues/25555) which would suggest that SocketOptions is the multiplatform version of this. Now it does not throw exceptions anymore.

I made similar changes to other branch in [here](https://github.com/ela-compil/BACnet/pull/55). I have been using this fix on linux devices for a long time now in my own fork.