### PR TITLE
Fixing resolution of broadcast address if multiple ip addresses are available

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -371,8 +371,8 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
             .Where(a => a.Address.AddressFamily == AddressFamily.InterNetwork)
             .ToArray();
 
-        return unicastAddresses.Length == 1
-            ? unicastAddresses.Single()
+        return unicastAddresses.Length >= 1
+            ? unicastAddresses.First()
             : null;
     }
 


### PR DESCRIPTION
If a network interface has multiple ip addresses configured or there are multiple network interfaces available and up, the broadcast address was resolved to 255.255.255.255 which is not supported by the bacnet standard.

To mitigate this behavior the first interface found is chosen and the correct broadcast address for this interface will be calculated and used for broadcasting.

This solves #93