### PR TITLE
Prevent reading past the closing tag of a cov subscription

### DIFF
--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -2358,7 +2358,7 @@ public class ASN1
             return -1;
         len += decode_unsigned(buffer, offset + len, lenValueType, out value.TimeRemaining);
 
-        if (len < apduLen && IS_OPENING_TAG(buffer[offset + len]))
+        if (len < apduLen && !IS_CLOSING_TAG(buffer[offset + len]))
         {
             decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValueType);
             if (tagNumber != 4)


### PR DESCRIPTION
A fix to issue #134 

This was already fixed in YABE back in r265 https://sourceforge.net/p/yetanotherbacnetexplorer/code/265/tree//trunk/Yabe/BACnetBase.cs?diff=52d7f6223e5e832718335a6a:264