### PR TITLE
Fixing issue when event notification is received with boolean value

### DIFF
--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -2403,6 +2403,7 @@ public class ASN1
         {
             case BacnetPropertyState.BacnetPropertyStateTypes.BOOLEAN_VALUE:
                 value.state.boolean_value = lenValueType == 1;
+                sectionLength++;
                 break;
 
             case BacnetPropertyState.BacnetPropertyStateTypes.BINARY_VALUE:


### PR DESCRIPTION
When a class notification is received, if a boolean value is defined it's not working:
![image](https://github.com/ela-compil/BACnet/assets/1136321/8b4845b9-a3f4-4faa-a12f-46adb3eb67e3)


  