### PR TITLE
Added support for deserialization of TIME_OF_DEVICE_RESTART

### DIFF
--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -2021,7 +2021,7 @@ public class ASN1
                 value.Value = v;
                 return tagLen;
             }
-            if (propertyId == BacnetPropertyIds.PROP_EVENT_TIME_STAMPS)
+            if (propertyId == BacnetPropertyIds.PROP_EVENT_TIME_STAMPS || propertyId == BacnetPropertyIds.PROP_TIME_OF_DEVICE_RESTART)
             {
                 decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValueType);
                 len++; // skip Tag


### PR DESCRIPTION
Since TIME_OF_DEVICE_RESTART is a BACnetTimeStamp, we can use the same deserialization code as the PROP_EVENT_TIME_STAMPS