### PR TITLE
test: ASN.1 primitive round-trip tests (+ int.MinValue signed-encode fix)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,6 @@ jobs:
     - name: Build (Linux - netstandard2.0)
       if: runner.os == 'Linux'
       run: dotnet build BACnet.csproj --no-restore -c Release -f netstandard2.0
+    # The test project targets net8.0, so it runs on both OSes.
+    - name: Test
+      run: dotnet test Tests/BACnet.Tests.csproj -c Release

--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -2,6 +2,9 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <!-- The core project lives at the repo root; sibling projects sit in their own
+         folders, so keep those folders out of this project's default globs. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**</DefaultItemExcludes>
     <Company>Ela-compil sp. z o. o.</Company>
     <Authors>Ela-compil and contributors</Authors>
     <Product>BACnet</Product>

--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -212,7 +212,7 @@ public class ASN1
             encode_signed16(buffer, (short)value);
         else if (value > -8388607 && value < 8388608)
             encode_signed24(buffer, (int)value);
-        else if (value > -2147483648 && value < 2147483648)
+        else if (value >= -2147483648 && value < 2147483648)
             encode_signed32(buffer, (int)value);
         else
             encode_signed64(buffer, value);

--- a/Tests/BACnet.Tests.csproj
+++ b/Tests/BACnet.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- net48 is deferred until Phase 6 removes the PacketDotNet/old-log4net chain from
+         the core (issue #112): that transitive System.* downgrade only breaks the net48
+         graph. The encode/decode tests are framework-agnostic, so no coverage is lost. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>System.IO.BACnet.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BACnet.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Serialize/Asn1PrimitiveTests.cs
+++ b/Tests/Serialize/Asn1PrimitiveTests.cs
@@ -1,0 +1,144 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Encode/decode round-trips for the ASN.1 application primitives, plus a few
+/// absolute-value checks against the worked examples in ANSI/ASHRAE 135-2016 Annex F.
+/// </summary>
+public class Asn1PrimitiveTests
+{
+    // --- Unsigned integers (across the 1/2/3/4-byte width boundaries) ---
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(255u)]
+    [InlineData(256u)]
+    [InlineData(65535u)]
+    [InlineData(65536u)]
+    [InlineData(16777215u)]
+    [InlineData(16777216u)]
+    [InlineData(uint.MaxValue)]
+    public void Unsigned_roundtrips(uint value)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_unsigned(buffer, value);
+        var bytes = buffer.ToArray();
+
+        var len = ASN1.decode_unsigned(bytes, 0, (uint)bytes.Length, out var decoded);
+
+        Assert.Equal(bytes.Length, len);
+        Assert.Equal(value, decoded);
+    }
+
+    // --- Signed integers (negatives and width boundaries) ---
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(-1)]
+    [InlineData(127)]
+    [InlineData(-128)]
+    [InlineData(32767)]
+    [InlineData(-32768)]
+    [InlineData(int.MaxValue)]
+    [InlineData(int.MinValue)]
+    public void Signed_roundtrips(int value)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_signed(buffer, value);
+        var bytes = buffer.ToArray();
+
+        var len = ASN1.decode_signed(bytes, 0, (uint)bytes.Length, out var decoded);
+
+        Assert.Equal(bytes.Length, len);
+        Assert.Equal(value, decoded);
+    }
+
+    // --- Real (IEEE-754 single precision, big-endian) ---
+
+    [Theory]
+    [InlineData(0f)]
+    [InlineData(1f)]
+    [InlineData(-1f)]
+    [InlineData(65.0f)]
+    [InlineData(3.1415927f)]
+    [InlineData(float.MaxValue)]
+    [InlineData(float.MinValue)]
+    public void Real_roundtrips(float value)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_real(buffer, value);
+        var bytes = buffer.ToArray();
+
+        var len = ASN1.decode_real(bytes, 0, out var decoded);
+
+        Assert.Equal(4, bytes.Length);
+        Assert.Equal(4, len);
+        Assert.Equal(value, decoded);
+    }
+
+    [Fact]
+    public void Real_matches_standard_encoding()
+    {
+        // ANSI/ASHRAE 135-2016 Annex F: the value 65.0 encodes to X'42820000'.
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_real(buffer, 65.0f);
+
+        Assert.Equal(new byte[] { 0x42, 0x82, 0x00, 0x00 }, buffer.ToArray());
+    }
+
+    // --- Double (IEEE-754 double precision, big-endian) ---
+
+    [Theory]
+    [InlineData(0d)]
+    [InlineData(1d)]
+    [InlineData(-1d)]
+    [InlineData(65.0d)]
+    [InlineData(double.MaxValue)]
+    [InlineData(double.MinValue)]
+    public void Double_roundtrips(double value)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_double(buffer, value);
+        var bytes = buffer.ToArray();
+
+        var len = ASN1.decode_double(bytes, 0, out var decoded);
+
+        Assert.Equal(8, bytes.Length);
+        Assert.Equal(8, len);
+        Assert.Equal(value, decoded);
+    }
+
+    // --- Object identifier (type + instance packed into 4 bytes) ---
+
+    [Theory]
+    [InlineData(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10u)]
+    [InlineData(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 0u)]
+    [InlineData(BacnetObjectTypes.OBJECT_DEVICE, 4194303u)] // BACNET_MAX_INSTANCE
+    public void ObjectId_roundtrips(BacnetObjectTypes type, uint instance)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_object_id(buffer, type, instance);
+        var bytes = buffer.ToArray();
+
+        var len = ASN1.decode_object_id(bytes, 0, out BacnetObjectTypes decodedType, out var decodedInstance);
+
+        Assert.Equal(4, bytes.Length);
+        Assert.Equal(4, len);
+        Assert.Equal(type, decodedType);
+        Assert.Equal(instance, decodedInstance);
+    }
+
+    [Fact]
+    public void ObjectId_matches_standard_encoding()
+    {
+        // Annex F: Analog Input, instance 10 -> X'0000000A'.
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_object_id(buffer, BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10);
+
+        Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x0A }, buffer.ToArray());
+    }
+}


### PR DESCRIPTION
First slice of the Phase 2 test suite — the regression net for the community-PR harvest.

**fix:** `encode_bacnet_signed` encoded `int.MinValue` as an 8-byte signed64, which `decode_signed` (1–4 bytes only) silently decoded back to `0`. Boundary `>` → `>=` so the full int32 range round-trips. The bug originates in YABE (`BACnetBase.cs`) and is unfixed in the IPECON fork too.

**test:** new `BACnet.Tests` project (xUnit v3, net8.0) — round-trips for unsigned/signed/real/double/object-id + Annex F golden vectors (65.0 → `42 82 00 00`, AnalogInput#10 → `00 00 00 0A`). 36 tests, green.

**ci:** run the suite on every push/PR (both OSes).

Notes:
- The core project globs the repo root, so `Tests/` is excluded from its default items.
- net48 test coverage is deferred to Phase 6 (removes the pcap/log4net chain, #112).
