### PR TITLE
fix: prevent stack overflow by deferring BeginReceive to the thread pool (#150)

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -215,15 +215,22 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
             {
                 if (connection.Client != null && !_disposing)
                 {
-                    try
+                    // BeginReceive ASAP to enable parallel processing (e.g. query additional data while processing a notification).
+                    // Defer to the thread pool so a synchronously-completing receive can't recurse into OnReceiveData and overflow the stack.
+                    ThreadPool.UnsafeQueueUserWorkItem(static state =>
                     {
-                        // BeginReceive ASAP to enable parallel processing (e.g. query additional data while processing a notification)
-                        connection.BeginReceive(OnReceiveData, connection);
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error($"Failed to restart data receive. {ex}");
-                    }
+                        var (transport, udp) = ((BacnetIpUdpProtocolTransport transport, UdpClient udp))state!;
+                        if (udp.Client == null || transport._disposing) return;
+
+                        try
+                        {
+                            udp.BeginReceive(transport.OnReceiveData, udp);
+                        }
+                        catch (Exception ex)
+                        {
+                            transport.Log.Error($"Failed to restart data receive. {ex}");
+                        }
+                    }, (this, connection));
                 }
             }
 


### PR DESCRIPTION
Clean extraction of the functional fix from #150 (remye06): defer `BeginReceive` to the thread pool so a synchronously-completing receive can't recurse into `OnReceiveData` and overflow the stack. Excludes the duplicated #148 change that #150 also carried.

**Cross-platform:** `ThreadPool` + APM sockets are core BCL (no OS-specific calls); compiles on net48/netstandard2.0/net8/net10.

**Verified:** builds all TFMs; 36 unit tests green; WhoIs → IAm discovery against a live YABE device working on Windows.
