### PR TITLE
fix: robustly serialize REAL/DOUBLE/UNSIGNED_INT property values (#143)

### DIFF
--- a/Storage/Property.cs
+++ b/Storage/Property.cs
@@ -89,9 +89,13 @@ public class Property
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_NULL:
                 return value.ToString(); // Modif FC
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL:
-                return ((float)value.Value).ToString(CultureInfo.InvariantCulture);
+                // Convert.ToSingle handles a value boxed as any numeric type (avoids an
+                // InvalidCastException when e.g. a double is boxed under a REAL tag).
+                return Convert.ToSingle(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_DOUBLE:
-                return ((double)value.Value).ToString(CultureInfo.InvariantCulture);
+                return Convert.ToDouble(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT:
+                return Convert.ToUInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_OCTET_STRING:
                 return Convert.ToBase64String((byte[])value.Value);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_CONTEXT_SPECIFIC_DECODED:

--- a/Tests/Storage/PropertySerializeTests.cs
+++ b/Tests/Storage/PropertySerializeTests.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.IO.BACnet.Storage;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Property.SerializeValue for numeric application tags. Regression tests for #143:
+/// double values must keep full precision, and values boxed as a different numeric
+/// type than their tag must convert instead of throwing InvalidCastException.
+/// </summary>
+public class PropertySerializeTests
+{
+    [Fact]
+    public void Double_keeps_full_precision()
+    {
+        const double value = 3.141592653589793d; // more precision than a float can hold
+        var bv = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_DOUBLE, value);
+
+        var s = Property.SerializeValue(bv, BacnetApplicationTags.BACNET_APPLICATION_TAG_DOUBLE);
+
+        Assert.Equal(value, double.Parse(s, CultureInfo.InvariantCulture)); // no double->float truncation
+    }
+
+    [Fact]
+    public void Real_serializes_invariant()
+    {
+        var bv = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL, 65.5f);
+
+        var s = Property.SerializeValue(bv, BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL);
+
+        Assert.Equal("65.5", s);
+    }
+
+    [Fact]
+    public void UnsignedInt_serializes()
+    {
+        var bv = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT, 4194303u);
+
+        var s = Property.SerializeValue(bv, BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT);
+
+        Assert.Equal("4194303", s);
+    }
+
+    [Fact]
+    public void Real_from_value_boxed_as_double_does_not_throw()
+    {
+        // The #143 scenario: a double boxed under a REAL tag. The old (float)value.Value
+        // cast threw InvalidCastException; Convert.ToSingle handles it.
+        var bv = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL, 42.5d);
+
+        var s = Property.SerializeValue(bv, BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL);
+
+        Assert.Equal("42.5", s);
+    }
+}


### PR DESCRIPTION
Corrected version of #143 (senthil-kumar-pa), with the double→float precision bug fixed and unit tests added.

`SerializeValue` cast `value.Value` directly to `float`/`double`, throwing `InvalidCastException` when the boxed value was a different numeric type. This uses `Convert.ToSingle`/`ToDouble` (culture-invariant) which handles cross-numeric boxing, preserves double precision, and adds the missing `UNSIGNED_INT` case. Not present in IPECON (still direct casts).

Verified: 40 unit tests green (4 new). Supersedes #143.
