### PR TITLE
fix: throw a clear error when the broadcast interface is ambiguous (#100)

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -399,9 +399,16 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
             .Where(a => a.Address.AddressFamily == AddressFamily.InterNetwork)
             .ToArray();
 
-        return unicastAddresses.Length == 1
-            ? unicastAddresses.Single()
-            : null;
+        if (unicastAddresses.Length == 1)
+            return unicastAddresses.Single();
+
+        // Zero or several candidate interfaces: the broadcast interface is ambiguous.
+        // Fail loudly instead of silently broadcasting to 255.255.255.255 or an arbitrary
+        // NIC — the caller must pass localEndpointIp to select the interface to use.
+        throw new InvalidOperationException(
+            $"Cannot determine the BACnet/IP broadcast address automatically: found {unicastAddresses.Length} " +
+            $"candidate IPv4 interface(s) [{string.Join(", ", unicastAddresses.Select(a => a.Address.ToString()))}]. " +
+            "Specify localEndpointIp in the BacnetIpUdpProtocolTransport constructor to select the interface.");
     }
 
     // A lot of problems on Mono (Raspberry) to get the correct broadcast @


### PR DESCRIPTION
Fail-loud broadcast-interface resolution, built on #100 (Alexander Heinisch / @pocketbroadcast).

On a multi-NIC host with no `localEndpointIp`, `GetAddressDefaultInterface` returned null and broadcasts silently fell back to 255.255.255.255. #100 proposed `First()`, but that is non-deterministic — verified on a 5-NIC box, the first candidate is APIPA `169.254.x`. This instead throws an `InvalidOperationException` that lists the candidate interfaces and directs the user to set `localEndpointIp`.

Verified: throws with no `localEndpointIp`; resolves `192.168.1.255` when set. Complementary to #157 (which recommends `localEndpointIp`). Supersedes #100.
