### PR TITLE
fix: decode WritePropertyMultiple with multiple objects (#158)

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -179,7 +179,7 @@ public class BacnetClient : IDisposable
     public event ReadPropertyMultipleRequestHandler OnReadPropertyMultipleRequest;
     public delegate void WritePropertyRequestHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, BacnetObjectId objectId, BacnetPropertyValue value, BacnetMaxSegments maxSegments);
     public event WritePropertyRequestHandler OnWritePropertyRequest;
-    public delegate void WritePropertyMultipleRequestHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, BacnetObjectId objectId, ICollection<BacnetPropertyValue> values, BacnetMaxSegments maxSegments);
+    public delegate void WritePropertyMultipleRequestHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, ICollection<BacnetWriteAccessSpecification> properties, BacnetMaxSegments maxSegments);
     public event WritePropertyMultipleRequestHandler OnWritePropertyMultipleRequest;
     public delegate void AtomicWriteFileRequestHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, bool isStream, BacnetObjectId objectId, int position, uint blockCount, byte[][] blocks, int[] counts, BacnetMaxSegments maxSegments);
     public event AtomicWriteFileRequestHandler OnAtomicWriteFileRequest;
@@ -274,8 +274,8 @@ public class BacnetClient : IDisposable
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROP_MULTIPLE && OnWritePropertyMultipleRequest != null)
             {
-                if (Services.DecodeWritePropertyMultiple(address, buffer, offset, length, out var objectId, out var values) >= 0)
-                    OnWritePropertyMultipleRequest(this, address, invokeId, objectId, values, maxSegments);
+                if (Services.DecodeWritePropertyMultiple(address, buffer, offset, length, out var properties) >= 0)
+                    OnWritePropertyMultipleRequest(this, address, invokeId, properties, maxSegments);
                 else
                 {
                     // DAL

--- a/Base/BacnetWriteAccessSpecification.cs
+++ b/Base/BacnetWriteAccessSpecification.cs
@@ -1,0 +1,13 @@
+namespace System.IO.BACnet;
+
+public struct BacnetWriteAccessSpecification
+{
+    public BacnetObjectId objectIdentifier;
+    public ICollection<BacnetPropertyValue> propertyValues;
+
+    public BacnetWriteAccessSpecification(BacnetObjectId objectIdentifier, ICollection<BacnetPropertyValue> propertyValues)
+    {
+        this.objectIdentifier = objectIdentifier;
+        this.propertyValues = propertyValues;
+    }
+}

--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -1075,6 +1075,102 @@ public class ASN1
         return len;
     }
 
+    public static int decode_write_access_specification(BacnetAddress address, byte[] buffer, int offset, int apdu_len, out BacnetWriteAccessSpecification value)
+    {
+        var len = 0;
+
+        value = new BacnetWriteAccessSpecification();
+
+        /* Tag 0: Object ID */
+        if (!decode_is_context_tag(buffer, offset + len, 0))
+            return -1;
+        len++;
+        len += decode_object_id(buffer, offset + len, out value.objectIdentifier.type,
+            out value.objectIdentifier.instance);
+
+        /* Tag 1: sequence of WriteAccessSpecification */
+        if (!decode_is_opening_tag_number(buffer, offset + len, 1))
+            return -1;
+        len++; /* opening tag is only one octet */
+
+        /* properties */
+        var propertyIdAndValues = new List<BacnetPropertyValue>();
+        while (apdu_len - len > 1 && !decode_is_closing_tag_number(buffer, offset + len, 1))
+        {
+            var p_ref = new BacnetPropertyValue();
+
+            /* Tag 0: propertyIdentifier */
+            if (!IS_CONTEXT_SPECIFIC(buffer[offset + len]))
+                return -1;
+
+            len += decode_tag_number_and_value(buffer, offset + len, out var tagNumber, out var lenValue_type);
+            if (tagNumber != 0)
+                return -1;
+
+            /* Should be at least the unsigned value + 1 tag left */
+            if (len + lenValue_type >= apdu_len)
+                return -1;
+            len += decode_enumerated(buffer, offset + len, lenValue_type, out p_ref.property.propertyIdentifier);
+            /* Assume most probable outcome */
+            p_ref.property.propertyArrayIndex = BACNET_ARRAY_ALL;
+            /* Tag 1: Optional propertyArrayIndex */
+            if (IS_CONTEXT_SPECIFIC(buffer[offset + len]) && !IS_CLOSING_TAG(buffer[offset + len]))
+            {
+                var tmp = decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue_type);
+                if (tagNumber == 1)
+                {
+                    len += tmp;
+                    /* Should be at least the unsigned array index + 1 tag left */
+                    if (len + lenValue_type >= apdu_len)
+                        return -1;
+                    len += decode_unsigned(buffer, offset + len, lenValue_type, out p_ref.property.propertyArrayIndex);
+                }
+            }
+
+            /* Tag 2: propertyValue */
+            len += decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue_type);
+            if (tagNumber != 2 || !decode_is_opening_tag(buffer, offset + len - 1))
+                return -1;
+
+            var bValues = new List<BacnetValue>();
+            while (!decode_is_closing_tag(buffer, offset + len))
+            {
+                var l = bacapp_decode_application_data(address, buffer, offset + len, apdu_len + offset,
+                    value.objectIdentifier.type, (BacnetPropertyIds)p_ref.property.propertyIdentifier, out var bValue);
+                if (l <= 0) return -1;
+                len += l;
+                bValues.Add(bValue);
+            }
+            len++; /* closing tag 2 */
+            p_ref.value = bValues;
+
+            /* Tag 3: Optional priority */
+            p_ref.priority = (byte)BACNET_NO_PRIORITY;
+            if (IS_CONTEXT_SPECIFIC(buffer[offset + len]) && !IS_CLOSING_TAG(buffer[offset + len]))
+            {
+                var tmp = decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue_type);
+                if (tagNumber == 3)
+                {
+                    len += tmp;
+                    /* Should be at least the unsigned priority + 1 tag left */
+                    if (len + lenValue_type >= apdu_len)
+                        return -1;
+                    len += decode_unsigned(buffer, offset + len, lenValue_type, out var priority);
+                    p_ref.priority = (byte)priority;
+                }
+            }
+            propertyIdAndValues.Add(p_ref);
+        }
+
+        /* closing tag */
+        if (!decode_is_closing_tag_number(buffer, offset + len, 1))
+            return -1;
+        len++;
+
+        value.propertyValues = propertyIdAndValues;
+        return len;
+    }
+
     public static int decode_device_obj_property_ref(byte[] buffer, int offset, int apdu_len, out BacnetDeviceObjectPropertyReference value)
     {
         var len = 0;

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -2397,91 +2397,21 @@ public class Services
         ASN1.encode_application_object_id(buffer, objectId.type, objectId.instance);
     }
 
-    public static int DecodeWritePropertyMultiple(BacnetAddress address, byte[] buffer, int offset, int apduLen, out BacnetObjectId objectId, out ICollection<BacnetPropertyValue> valuesRefs)
+    public static int DecodeWritePropertyMultiple(BacnetAddress address, byte[] buffer, int offset, int apduLen, out ICollection<BacnetWriteAccessSpecification> properties)
     {
         var len = 0;
-        objectId = new BacnetObjectId();
-        valuesRefs = null;
+        var values = new List<BacnetWriteAccessSpecification>();
+        properties = null;
 
-        /* Context tag 0 - Object ID */
-        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out var tagNumber, out var lenValue);
-        if (tagNumber == 0 && apduLen > len)
+        while (apduLen - len > 0)
         {
-            apduLen -= len;
-            if (apduLen >= 4)
-            {
-                len += ASN1.decode_object_id(buffer, offset + len, out objectId.type, out objectId.instance);
-            }
-            else
-                return -1;
-        }
-        else
-            return -1;
-
-        /* Tag 1: sequence of WriteAccessSpecification */
-        if (!ASN1.decode_is_opening_tag_number(buffer, offset + len, 1))
-            return -1;
-        len++;
-
-        var _values = new LinkedList<BacnetPropertyValue>();
-        while (apduLen - len > 1)
-        {
-            var newEntry = new BacnetPropertyValue();
-
-            /* tag 0 - Property Identifier */
-            len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue);
-            uint propertyId;
-            if (tagNumber == 0)
-                len += ASN1.decode_enumerated(buffer, offset + len, lenValue, out propertyId);
-            else
-                return -1;
-
-            /* tag 1 - Property Array Index - optional */
-            var ulVal = ASN1.BACNET_ARRAY_ALL;
-            len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue);
-            if (tagNumber == 1)
-            {
-                len += ASN1.decode_unsigned(buffer, offset + len, lenValue, out ulVal);
-                len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue);
-            }
-            newEntry.property = new BacnetPropertyReference(propertyId, ulVal);
-
-            /* tag 2 - Property Value */
-            if (tagNumber == 2 && ASN1.decode_is_opening_tag(buffer, offset + len - 1))
-            {
-                var values = new List<BacnetValue>();
-                while (!ASN1.decode_is_closing_tag(buffer, offset + len))
-                {
-                    var l = ASN1.bacapp_decode_application_data(address, buffer, offset + len, apduLen + offset, objectId.type, (BacnetPropertyIds)propertyId, out var value);
-                    if (l <= 0) return -1;
-                    len += l;
-                    values.Add(value);
-                }
-                len++;
-                newEntry.value = values;
-            }
-            else
-                return -1;
-
-            /* tag 3 - Priority - optional */
-            ulVal = ASN1.BACNET_NO_PRIORITY;
-            len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue);
-            if (tagNumber == 3)
-                len += ASN1.decode_unsigned(buffer, offset + len, lenValue, out ulVal);
-            else
-                len--;
-            newEntry.priority = (byte)ulVal;
-
-            _values.AddLast(newEntry);
+            var tmp = ASN1.decode_write_access_specification(address, buffer, offset + len, apduLen - len, out var value);
+            if (tmp < 0) return -1;
+            len += tmp;
+            values.Add(value);
         }
 
-        /* Closing tag 1 - List of Properties */
-        if (!ASN1.decode_is_closing_tag_number(buffer, offset + len, 1))
-            return -1;
-        len++;
-
-        valuesRefs = _values;
-
+        properties = values;
         return len;
     }
 

--- a/Tests/Serialize/WritePropertyMultipleTests.cs
+++ b/Tests/Serialize/WritePropertyMultipleTests.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// WritePropertyMultiple is a SEQUENCE OF WriteAccessSpecification (ASHRAE 135), i.e. a single
+/// request may target several objects. Regression test for #158: the decoder must return every
+/// object, not just the first.
+/// </summary>
+public class WritePropertyMultipleTests
+{
+    private static BacnetPropertyValue PresentValue(float value) => new BacnetPropertyValue
+    {
+        property = new BacnetPropertyReference((uint)BacnetPropertyIds.PROP_PRESENT_VALUE, ASN1.BACNET_ARRAY_ALL),
+        value = new List<BacnetValue> { new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL, value) },
+        priority = (byte)ASN1.BACNET_NO_PRIORITY,
+    };
+
+    [Fact]
+    public void Decodes_all_objects_in_a_multi_object_request()
+    {
+        // Encode two write-access-specifications back to back (as a multi-object WPM body).
+        var buffer = new EncodeBuffer();
+        Services.EncodeWritePropertyMultiple(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1017),
+            new List<BacnetPropertyValue> { PresentValue(50f) });
+        Services.EncodeWritePropertyMultiple(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1016),
+            new List<BacnetPropertyValue> { PresentValue(40f) });
+        var bytes = buffer.ToArray();
+
+        var address = new BacnetAddress(BacnetAddressTypes.IP, "192.168.1.1");
+        var len = Services.DecodeWritePropertyMultiple(address, bytes, 0, bytes.Length, out var specs);
+
+        Assert.True(len >= 0);
+        Assert.Equal(2, specs.Count);
+
+        var list = specs.ToList();
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1017), list[0].objectIdentifier);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1016), list[1].objectIdentifier);
+        Assert.Equal(50f, (float)list[0].propertyValues.First().value.First().Value);
+        Assert.Equal(40f, (float)list[1].propertyValues.First().value.First().Value);
+        Assert.Equal((uint)BacnetPropertyIds.PROP_PRESENT_VALUE, list[0].propertyValues.First().property.propertyIdentifier);
+    }
+}


### PR DESCRIPTION
Lands the WritePropertyMultiple multi-object fix from #158 (@imurasawa), cherry-picked as the **isolated functional change** — the original PR is stacked on #157 + a line-ending normalization commit and so was CONFLICTING.

WritePropertyMultiple is a `SEQUENCE OF WriteAccessSpecification` (ASHRAE 135-2016, WritePropertyMultiple-Request), but `DecodeWritePropertyMultiple` decoded only the **first** object, so multi-object requests from commercial BMS clients were rejected. It now loops via a new `ASN1.decode_write_access_specification` (mirroring ReadPropertyMultiple) + a `BacnetWriteAccessSpecification` type.

**BREAKING:** `OnWritePropertyMultipleRequest` now receives `ICollection<BacnetWriteAccessSpecification>` instead of `(objectId, values)`.

Supersedes #158.
