### PR TITLE
fix: serialize DATE/TIME/DATETIME storage values culture-invariantly (#159)

### DIFF
--- a/Storage/Property.cs
+++ b/Storage/Property.cs
@@ -68,9 +68,14 @@ public class Property
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_ENUMERATED:
                 return new BacnetValue(type, uint.Parse(value));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_DATE:
-                return new BacnetValue(type, DateTime.Parse(value));
+                // Format: yyyy/MM/dd (bacnet-stack compatible)
+                return new BacnetValue(type, DateTime.ParseExact(value, "yyyy/MM/dd", CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_TIME:
-                return new BacnetValue(type, DateTime.Parse(value));
+                // Format: HH:mm:ss.hh where hh = hundredths (0-99) (bacnet-stack compatible)
+                return new BacnetValue(type, DateTime.ParseExact(value, "HH:mm:ss.ff", CultureInfo.InvariantCulture));
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_DATETIME:
+                // Format: yyyy/MM/dd-HH:mm:ss.hh where hh = hundredths (0-99) (bacnet-stack compatible)
+                return new BacnetValue(type, DateTime.ParseExact(value, "yyyy/MM/dd-HH:mm:ss.ff", CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_OBJECT_ID:
                 return new BacnetValue(type, BacnetObjectId.Parse(value));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_READ_ACCESS_SPECIFICATION:
@@ -104,6 +109,17 @@ public class Property
                         : string.Join(";", ((BacnetValue[])value.Value)
                             .Select(v => SerializeValue(v, v.Tag)));
                 }
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_DATE:
+                // Format: yyyy/MM/dd (bacnet-stack compatible)
+                return ((DateTime)value.Value).ToString("yyyy/MM/dd", CultureInfo.InvariantCulture);
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_TIME:
+                // Format: HH:mm:ss.hh where hh = hundredths (0-99) (bacnet-stack compatible)
+                return ((DateTime)value.Value).ToString("HH:mm:ss.", CultureInfo.InvariantCulture)
+                    + (((DateTime)value.Value).Millisecond / 10).ToString("D2", CultureInfo.InvariantCulture);
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_DATETIME:
+                // Format: yyyy/MM/dd-HH:mm:ss.hh where hh = hundredths (0-99) (bacnet-stack compatible)
+                return ((DateTime)value.Value).ToString("yyyy/MM/dd-HH:mm:ss.", CultureInfo.InvariantCulture)
+                    + (((DateTime)value.Value).Millisecond / 10).ToString("D2", CultureInfo.InvariantCulture);
             default:
                 return value.Value.ToString();
         }

--- a/Tests/Storage/PropertyDateTimeTests.cs
+++ b/Tests/Storage/PropertyDateTimeTests.cs
@@ -1,0 +1,52 @@
+using System.IO.BACnet.Storage;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Storage serialization of DATE/TIME/DATETIME must be culture-invariant and round-trip
+/// (regression test for #159; TIME resolution is hundredths of a second per BACnet).
+/// </summary>
+public class PropertyDateTimeTests
+{
+    private static string Serialize(BacnetApplicationTags tag, DateTime value) =>
+        Property.SerializeValue(new BacnetValue(tag, value), tag);
+
+    private static DateTime Deserialize(BacnetApplicationTags tag, string value) =>
+        (DateTime)Property.DeserializeValue(value, tag).Value;
+
+    [Fact]
+    public void Date_serializes_invariant_and_roundtrips()
+    {
+        var date = new DateTime(2024, 3, 5);
+
+        var s = Serialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_DATE, date);
+
+        Assert.Equal("2024/03/05", s);
+        Assert.Equal(date, Deserialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_DATE, s));
+    }
+
+    [Fact]
+    public void Time_serializes_with_hundredths_and_roundtrips()
+    {
+        var time = new DateTime(1, 1, 1, 13, 45, 30).AddMilliseconds(120); // 13:45:30.12
+
+        var s = Serialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_TIME, time);
+
+        Assert.Equal("13:45:30.12", s);
+        var back = Deserialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_TIME, s);
+        Assert.Equal(13, back.Hour);
+        Assert.Equal(12, back.Millisecond / 10); // hundredths preserved
+    }
+
+    [Fact]
+    public void DateTime_serializes_invariant_and_roundtrips()
+    {
+        var dt = new DateTime(2024, 12, 31, 23, 59, 58).AddMilliseconds(90); // .09
+
+        var s = Serialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_DATETIME, dt);
+
+        Assert.Equal("2024/12/31-23:59:58.09", s);
+        Assert.Equal(dt, Deserialize(BacnetApplicationTags.BACNET_APPLICATION_TAG_DATETIME, s));
+    }
+}


### PR DESCRIPTION
Lands the DATE/TIME/DATETIME storage serialization fix from #159 (imurasawa), cherry-picked as the **isolated functional change** (the PR was stacked on #157 + a line-ending normalization + #158).

`DeviceStorage` serialized DATE/TIME through the current culture and had **no DATETIME case**, so persisted values didn't round-trip across locales. Now uses invariant, bacnet-stack-compatible formats — DATE `yyyy/MM/dd`, TIME `HH:mm:ss.hh` (hundredths), DATETIME `yyyy/MM/dd-HH:mm:ss.hh` — and adds the missing DATETIME case both ways. **Not present in YABE or IPECON** (both still use culture-dependent `DateTime.Parse`).

**Breaking** only for reloading old culture-formatted storage files (noted for 4.0 upgrade notes).

Verified: **44 unit tests green** (3 new round-trip). Commits: **imurasawa** (fix) + **Jakub** (test). Supersedes #159.
