### PR TITLE
fix: correct BacnetBitString bit count; type trend-log status flags as 4-bit (#8)

### DIFF
--- a/Base/BacnetBitString.cs
+++ b/Base/BacnetBitString.cs
@@ -80,12 +80,15 @@ public struct BacnetBitString
             : 0;
     }
 
-    public static BacnetBitString ConvertFromInt(uint value)
+    public static BacnetBitString ConvertFromInt(uint value, byte? bitsUsed = null)
     {
         return new BacnetBitString
         {
             value = BitConverter.GetBytes(value),
-            bits_used = (byte)Math.Ceiling(Math.Log(value, 2))
+            // Significant bits = floor(log2(value)) + 1. Math.Ceiling(log2) was wrong for exact
+            // powers of two (4 -> 2 instead of 3) and for value 1. Callers that know the fixed width
+            // (e.g. the 4-bit BACnetStatusFlags) can pass it explicitly.
+            bits_used = bitsUsed ?? (byte)(Math.Log(value, 2) + 1)
         };
     }
 };

--- a/Base/BacnetLogRecord.cs
+++ b/Base/BacnetLogRecord.cs
@@ -19,13 +19,13 @@ public struct BacnetLogRecord
     private object any_value;
     /* } */
 
-    public BacnetBitString statusFlags;
+    public BacnetStatusFlags statusFlags;
 
-    public BacnetLogRecord(BacnetTrendLogValueType type, object value, DateTime stamp, uint status)
+    public BacnetLogRecord(BacnetTrendLogValueType type, object value, DateTime stamp, BacnetStatusFlags status)
     {
         this.type = type;
         timestamp = stamp;
-        statusFlags = BacnetBitString.ConvertFromInt(status);
+        statusFlags = status;
         any_value = null;
         Value = value;
     }

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -2541,11 +2541,12 @@ public class Services
             ASN1.encode_closing_tag(buffer, 1);
         }
 
-        /* Tag 2: status */
-        if (record.statusFlags.bits_used > 0)
+        /* Tag 2: status (BACnetStatusFlags is a fixed 4-bit string) */
+        var recordStatusFlags = BacnetBitString.ConvertFromInt((uint)record.statusFlags, 4);
+        if (recordStatusFlags.bits_used > 0)
         {
             ASN1.encode_opening_tag(buffer, 2);
-            ASN1.encode_application_bitstring(buffer, record.statusFlags);
+            ASN1.encode_application_bitstring(buffer, recordStatusFlags);
             ASN1.encode_closing_tag(buffer, 2);
         }
     }
@@ -2656,7 +2657,8 @@ public class Services
             return len;
 
         len += l;
-        len += ASN1.decode_bitstring(buffer, offset + len, 2, out var statusFlags);
+        len += ASN1.decode_bitstring(buffer, offset + len, 2, out var statusFlagsBits);
+        var statusFlags = (BacnetStatusFlags)statusFlagsBits.ConvertToInt();
 
         //set status to all returns
         for (var curveNumber = 0; curveNumber < nCurves; curveNumber++)

--- a/Tests/Base/BacnetBitStringTests.cs
+++ b/Tests/Base/BacnetBitStringTests.cs
@@ -1,0 +1,36 @@
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// BacnetBitString.ConvertFromInt bit-length calculation (regression for #8 / #11):
+/// bits_used must be floor(log2(value)) + 1, which the old Math.Ceiling(log2) got wrong
+/// for exact powers of two and for value 1.
+/// </summary>
+public class BacnetBitStringTests
+{
+    [Theory]
+    [InlineData(1u, 1)]    // 0b1
+    [InlineData(2u, 2)]    // 0b10
+    [InlineData(3u, 2)]    // 0b11
+    [InlineData(4u, 3)]    // 0b100  - old Ceiling(log2) gave 2
+    [InlineData(5u, 3)]
+    [InlineData(7u, 3)]    // 0b111
+    [InlineData(8u, 4)]    // 0b1000 - old gave 3
+    [InlineData(255u, 8)]
+    [InlineData(256u, 9)]  // 0b1_0000_0000
+    public void ConvertFromInt_uses_correct_bit_length(uint value, int expectedBits)
+    {
+        Assert.Equal(expectedBits, BacnetBitString.ConvertFromInt(value).bits_used);
+    }
+
+    [Theory]
+    [InlineData(0b0000u)] // no flags
+    [InlineData(0b0010u)] // fault only
+    [InlineData(0b1111u)] // all four
+    public void ConvertFromInt_honors_explicit_bits_used(uint value)
+    {
+        // BACnetStatusFlags is a fixed 4-bit string regardless of which bits are set.
+        Assert.Equal(4, BacnetBitString.ConvertFromInt(value, 4).bits_used);
+    }
+}


### PR DESCRIPTION
Fixes **#8** (Trend Log Object status flags) and lands the fixes from #11 (reconstructed onto `v4`, since the 2017 PR conflicts and carried obsolete MSTest scaffolding).

- `BacnetBitString.ConvertFromInt` computed `bits_used = Math.Ceiling(Math.Log(value,2))`, which **under-counts exact powers of two** (4 → 2 bits instead of 3) and value 1 (→ 0). Now `floor(log2)+1`, with an optional explicit `bitsUsed`.
- `BacnetLogRecord.statusFlags` retyped `BacnetBitString` → **`BacnetStatusFlags`**; trend-log (ReadRange) records encode/decode it as the fixed **4-bit** `BACnetStatusFlags` string (spec: `BIT STRING { in-alarm, fault, overridden, out-of-service }`).

**Unfixed in YABE, IPECON, and ela-compil** — novel fix. **BREAKING:** `BacnetLogRecord.statusFlags` field type + ctor signature (noted for 4.0 upgrade notes).

**Follow-up (Phase 14):** event-notification and ReadRange-ack status flags (`BACnetClient.cs` `ConvertFromInt((uint)status)`) still don't pass an explicit 4-bit width.

Verified: **56 unit tests green** (+12 for the bit-length calc). Supersedes #11.
