### PR TITLE
fix: encode ReadRange result flags as fixed 3-bit BIT STRING

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2860,7 +2860,10 @@ public class BacnetClient : IDisposable
         {
             SendComplexAck(adr, invokeId, segmentation, BacnetConfirmedServices.SERVICE_CONFIRMED_READ_RANGE, b =>
             {
-                Services.EncodeReadRangeAcknowledge(b, objectId, property.propertyIdentifier, property.propertyArrayIndex, BacnetBitString.ConvertFromInt((uint)status), itemCount, applicationData, requestType, firstSequenceNo);
+                // BACnetResultFlags is a fixed 3-bit BIT STRING {firstItem, lastItem, moreItems}; pass the
+                // width explicitly so all-false (or high-bit-clear) flags still encode three bits instead of
+                // an empty bitstring (reported by @BennoMeijer, PR #15).
+                Services.EncodeReadRangeAcknowledge(b, objectId, property.propertyIdentifier, property.propertyArrayIndex, BacnetBitString.ConvertFromInt((uint)status, 3), itemCount, applicationData, requestType, firstSequenceNo);
             });
         });
     }

--- a/Tests/Serialize/ReadRangeResultFlagsTests.cs
+++ b/Tests/Serialize/ReadRangeResultFlagsTests.cs
@@ -1,0 +1,30 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Regression tests for the ReadRange-ACK result flags (reported by @BennoMeijer, PR #15).
+/// BACnetResultFlags ::= BIT STRING { firstItem(0), lastItem(1), moreItems(2) } is a fixed 3-bit
+/// field. <see cref="BacnetClient.ReadRangeResponse"/> builds it with
+/// <c>BacnetBitString.ConvertFromInt((uint)status, 3)</c>; deriving the width from the value instead
+/// (the old bug) collapsed all-false / high-bit-clear flags into a shorter — non-conformant — bitstring.
+/// These lock the fixed-width wire format the call site now produces.
+/// </summary>
+public class ReadRangeResultFlagsTests
+{
+    [Theory]
+    // context tag 3, 5 unused bits, one MSB-first data byte. Without the explicit width these encoded
+    // as 0 / 1 / 2 bits respectively (a shorter bitstring), so a peer saw fewer than three flags.
+    [InlineData(BacnetResultFlags.NONE, 0x00)]                                        // 000
+    [InlineData(BacnetResultFlags.FIRST_ITEM, 0x80)]                                  // 100
+    [InlineData(BacnetResultFlags.FIRST_ITEM | BacnetResultFlags.LAST_ITEM, 0xC0)]    // 110
+    [InlineData(BacnetResultFlags.MORE_ITEMS, 0x20)]                                  // 001
+    public void ResultFlags_always_encode_three_bits(BacnetResultFlags status, byte expectedData)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_context_bitstring(buffer, 3, BacnetBitString.ConvertFromInt((uint)status, 3));
+
+        Assert.Equal(new byte[] { 0x3A, 0x05, expectedData }, buffer.ToArray());
+    }
+}


### PR DESCRIPTION
`ReadRangeResponse` derived the `BACnetResultFlags` bitstring width from the enum value via `ConvertFromInt((uint)status)`, so all-false or high-bit-clear flags collapsed into a shorter, non-conformant bitstring (`NONE` → 0 bits, `FIRST_ITEM` → 1 bit, `FIRST_ITEM|LAST_ITEM` → 2 bits).

Per ASHRAE 135 clause 20.2.10, bit strings defined in the standard are encoded in the order of definition with all defined bits present; `BACnetResultFlags ::= BIT STRING { first-item(0), last-item(1), more-items(2) }` is a fixed 3-bit field. Pass the width explicitly so a peer always sees the three flags.

Adds a regression test locking the fixed-width wire format (`3A 05 XX`).

Reported in #15 by @BennoMeijer, which this supersedes.