### PR TITLE
chore: shared build config (Directory.Build.props + CPM) and wire tests into solution

### DIFF
--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -1,23 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>latest</LangVersion>
     <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
     <!-- The core project lives at the repo root; sibling projects sit in their own
          folders, so keep those folders out of this project's default globs. -->
     <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**</DefaultItemExcludes>
-    <Company>Ela-compil sp. z o. o.</Company>
-    <Authors>Ela-compil and contributors</Authors>
-    <Product>BACnet</Product>
-    <Copyright>Copyright (c) Ela-compil sp. z o. o.</Copyright>
-    <Description>BACnet protocol library for .NET</Description>
     <OutputType>Library</OutputType>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RootNamespace>System.IO.BACnet</RootNamespace>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <!-- Package metadata shared across the repo lives in Directory.Build.props; only the
+         core-package-specific bits stay here. -->
+    <Description>BACnet protocol library for .NET</Description>
     <PackageTags>bacnet;btl;automation</PackageTags>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/ela-compil/BACnet</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/ela-compil/BACnet/master/logo.png</PackageIconUrl>
   </PropertyGroup>
@@ -26,9 +19,11 @@
     <None Include="logo.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
+  <!-- Package versions are centralised in Directory.Packages.props (CPM). -->
+
   <!-- Vendor Packages -->
   <ItemGroup>
-    <PackageReference Include="Common.Logging" Version="3.4.1" />
+    <PackageReference Include="Common.Logging" />
   </ItemGroup>
 
   <!-- Microsoft Packages targeting .net framework v4.8 -->
@@ -38,19 +33,19 @@
 
   <!-- Vendor Packages targeting .net framework v4.8 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="PacketDotNet" Version="0.13.0" />
-    <PackageReference Include="SharpPcap" Version="4.2.0" />
+    <PackageReference Include="PacketDotNet" />
+    <PackageReference Include="SharpPcap" />
   </ItemGroup>
 
   <!-- Microsoft Packages targeting .net standard 2.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.IO.Ports" Version="5.0.1" />
+    <PackageReference Include="System.IO.Ports" />
   </ItemGroup>
 
   <!-- Vendor Packages targeting .net standard 2.0 -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="PacketDotNet" Version="0.19.3" />
-    <PackageReference Include="SharpPcap" Version="4.5.0" />
+    <PackageReference Include="PacketDotNet" />
+    <PackageReference Include="SharpPcap" />
   </ItemGroup>
 
 </Project>

--- a/BACnet.sln
+++ b/BACnet.sln
@@ -5,19 +5,50 @@ VisualStudioVersion = 17.1.31911.260
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BACnet", "BACnet.csproj", "{66832876-01FC-4B7C-8D92-54195773FABF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BACnet.Tests", "Tests\BACnet.Tests.csproj", "{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|x64.Build.0 = Debug|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Debug|x86.Build.0 = Debug|Any CPU
 		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|x64.ActiveCfg = Release|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|x64.Build.0 = Release|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|x86.ActiveCfg = Release|Any CPU
+		{66832876-01FC-4B7C-8D92-54195773FABF}.Release|x86.Build.0 = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x64.Build.0 = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4BD775C7-0626-4B2B-969B-285F36768D4D}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,22 @@
+<Project>
+
+  <!-- Shared settings for every project in the repo. Project-specific metadata
+       (Description, PackageTags, TargetFrameworks, package icon) stays in each .csproj. -->
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+
+    <!-- Organisation-wide package metadata -->
+    <Company>Ela-compil sp. z o. o.</Company>
+    <Authors>Ela-compil and contributors</Authors>
+    <Product>BACnet</Product>
+    <Copyright>Copyright (c) Ela-compil sp. z o. o.</Copyright>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/ela-compil/BACnet</RepositoryUrl>
+
+    <!-- Packing is a release-time concern handled by the CI pack/publish workflow (Phase 9),
+         not every local build. MinVer-based versioning is wired in Phase 8. -->
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+  </PropertyGroup>
+
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,32 @@
+<Project>
+
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- Core dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="Common.Logging" Version="3.4.1" />
+  </ItemGroup>
+
+  <!-- pcap / serial stack. Versions differ per target framework; this whole group leaves the
+       core when the native transports are split into BACnet.Ethernet / BACnet.Serial (Phase 6). -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+    <PackageVersion Include="PacketDotNet" Version="0.13.0" />
+    <PackageVersion Include="SharpPcap" Version="4.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageVersion Include="PacketDotNet" Version="0.19.3" />
+    <PackageVersion Include="SharpPcap" Version="4.5.0" />
+    <PackageVersion Include="System.IO.Ports" Version="5.0.1" />
+  </ItemGroup>
+
+  <!-- Test dependencies -->
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/BACnet.Tests.csproj
+++ b/Tests/BACnet.Tests.csproj
@@ -5,7 +5,6 @@
          the core (issue #112): that transitive System.* downgrade only breaks the net48
          graph. The encode/decode tests are framework-agnostic, so no coverage is lost. -->
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -16,17 +15,18 @@
     <ProjectReference Include="..\BACnet.csproj" />
   </ItemGroup>
 
+  <!-- Package versions are centralised in Directory.Packages.props (CPM). -->
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!-- Pin restore to nuget.org so builds are reproducible regardless of machine-level
+         sources, and so Central Package Management has a single source (avoids NU1507). -->
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Phase 4 of the 4.0 modernization — shared build configuration, kept **flat** (no `src/` move; nothing moved on disk).

- **`Directory.Build.props`** (new) — hoists org-wide package metadata (Company, Authors, Copyright, license, repository) and `LangVersion` out of the core csproj; sets `GeneratePackageOnBuild=false` (packing moves to the Phase 9 release workflow). Staged to host MinVer in Phase 8.
- **`Directory.Packages.props`** (new) — enables Central Package Management; all package versions now live in one place. The pcap/serial versions stay per-TFM until Phase 6 splits those transports out of the core.
- **`nuget.config`** (new) — pins restore to nuget.org (single source; avoids NU1507 under CPM; deterministic restore regardless of machine-level feeds).
- **`BACnet.csproj` / `Tests/BACnet.Tests.csproj`** — drop hoisted metadata and per-reference `Version=` attributes (now from CPM).
- **`BACnet.sln`** — adds `BACnet.Tests`, so `dotnet build`/`dotnet test` on the solution discovers and runs the suite.

**Verified locally:** `dotnet build BACnet.sln -c Release` clean (net48 + netstandard2.0 core, net8.0 tests, no warnings); `dotnet test BACnet.sln` → 119 passing.