### PR TITLE
new: multi-target the core (net48;netstandard2.0;net8.0;net10.0)

### DIFF
--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net48;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <!-- The core project lives at the repo root; sibling projects sit in their own
          folders, so keep those folders out of this project's default globs. -->
     <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**</DefaultItemExcludes>
@@ -31,21 +31,15 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <!-- Vendor Packages targeting .net framework v4.8 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
+  <!-- pcap stack for the Ethernet transport (all targets; versions vary per TFM via CPM). -->
+  <ItemGroup>
     <PackageReference Include="PacketDotNet" />
     <PackageReference Include="SharpPcap" />
   </ItemGroup>
 
-  <!-- Microsoft Packages targeting .net standard 2.0 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <!-- System.IO.Ports for the serial transports: from the BCL on net48, a package elsewhere. -->
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <PackageReference Include="System.IO.Ports" />
-  </ItemGroup>
-
-  <!-- Vendor Packages targeting .net standard 2.0 -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="PacketDotNet" />
-    <PackageReference Include="SharpPcap" />
   </ItemGroup>
 
 </Project>

--- a/Base/BacnetAddress.cs
+++ b/Base/BacnetAddress.cs
@@ -38,8 +38,10 @@ public class BacnetAddress : ASN1.IEncode
                     ? ushort.Parse(addressParts[1])
                     : (ushort)0xBAC0);
 
+                // Array.Reverse (in place) rather than the LINQ Reverse().ToArray(): on net8/net10
+                // byte[].Reverse() binds to the span-based, void-returning overload (first-class spans).
                 if (BitConverter.IsLittleEndian)
-                    portBytes = portBytes.Reverse().ToArray();
+                    Array.Reverse(portBytes);
 
                 Array.Copy(portBytes, 0, adr, addressBytes.Length, portBytes.Length);
                 break;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,10 @@
     <!-- Packing is a release-time concern handled by the CI pack/publish workflow (Phase 9),
          not every local build. MinVer-based versioning is wired in Phase 8. -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+
+    <!-- Pin AssemblyVersion to major-only so net48 consumers avoid binding-redirect churn on every
+         release; the package/file versions float (MinVer, Phase 8). -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,16 +9,27 @@
     <PackageVersion Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>
 
-  <!-- pcap / serial stack. Versions differ per target framework; this whole group leaves the
+  <!-- pcap stack. net48 pins the old API-compatible builds; every newer target shares the
+       netstandard2.0-compatible builds (consumable by net8/net10). This whole stack leaves the
        core when the native transports are split into BACnet.Ethernet / BACnet.Serial (Phase 6). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageVersion Include="PacketDotNet" Version="0.13.0" />
     <PackageVersion Include="SharpPcap" Version="4.2.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
     <PackageVersion Include="PacketDotNet" Version="0.19.3" />
     <PackageVersion Include="SharpPcap" Version="4.5.0" />
+  </ItemGroup>
+
+  <!-- System.IO.Ports: in the BCL for net48; a NuGet package everywhere else, versioned per runtime. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageVersion Include="System.IO.Ports" Version="5.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageVersion Include="System.IO.Ports" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageVersion Include="System.IO.Ports" Version="10.0.0" />
   </ItemGroup>
 
   <!-- Test dependencies -->

--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -151,16 +151,20 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
     /// <param name="dontFragment"></param>
     private void SetDontFragment(UdpClient client, bool dontFragment)
     {
-        if (Environment.OSVersion.Platform != PlatformID.MacOSX)
+        // Setting DontFragment throws on macOS (dotnet/runtime#27653). The old guard tested
+        // Environment.OSVersion.Platform against PlatformID.MacOSX, but modern .NET reports Unix
+        // (never MacOSX) there, so it never actually skipped macOS. RuntimeInformation detects the
+        // OS correctly on .NET Framework and .NET Core alike.
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return;
+
+        try
         {
-            try
-            {
-                client.DontFragment = dontFragment;
-            }
-            catch (SocketException e)
-            {
-                Log.WarnFormat("Unable to set DontFragment", e);
-            }
+            client.DontFragment = dontFragment;
+        }
+        catch (SocketException e)
+        {
+            Log.WarnFormat("Unable to set DontFragment", e);
         }
     }
 
@@ -172,15 +176,18 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
     /// </remarks>
     private static void DisableConnReset(UdpClient client)
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-        {
-            const uint IOC_IN = 0x80000000;
-            const uint IOC_VENDOR = 0x18000000;
-            const uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
+        // SIO_UDP_CONNRESET is a Windows-only ioctl. RuntimeInformation.IsOSPlatform is the modern,
+        // analyzer-recognised guard (silences CA1416 when targeting net8/net10) and is correct on
+        // both .NET Framework and .NET Core, unlike Environment.OSVersion.Platform.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
 
-            client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
-                new[] { System.Convert.ToByte(false) }, null);
-        }
+        const uint IOC_IN = 0x80000000;
+        const uint IOC_VENDOR = 0x18000000;
+        const uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
+
+        client?.Client.IOControl(unchecked((int)SIO_UDP_CONNRESET),
+            new[] { System.Convert.ToByte(false) }, null);
     }
 
     protected void Close()


### PR DESCRIPTION
Phase 5 of the 4.0 modernization — multi-target the core library.

## Changes
- **TargetFrameworks** → `net48;netstandard2.0;net8.0;net10.0`. The pcap stack (SharpPcap 4.5.0 / PacketDotNet 0.19.3) and `System.IO.Ports` restore cleanly on the new targets; `System.IO.Ports` is versioned per runtime (5.0.1 / 8.0.0 / 10.0.0) and dropped on net48 (it ships in the BCL there).
- **OS-detection swap** in `BacnetIpUdpProtocolTransport`: both checks move from `Environment.OSVersion.Platform` to `RuntimeInformation.IsOSPlatform(...)`. This correctly skips `DontFragment` on macOS (**#91** — modern .NET reports `Unix`, never `MacOSX`) and makes the Windows-only `SIO_UDP_CONNRESET` guard analyzer-recognised (CA1416). Reconciled with the already-merged #157 (socket binding is untouched).
- **`BacnetAddress`**: reverse port bytes with `Array.Reverse` in place — `byte[].Reverse()` binds to the void, span-based overload on net8/net10 (first-class spans), which broke the old `Reverse().ToArray()`.
- **AssemblyVersion** pinned to `4.0.0.0` (major-only) to avoid net48 binding-redirect churn; package/file versions float via MinVer (Phase 8).

## Notes
- Flat layout preserved; nothing moved on disk.
- Restore surfaces **NU1902/NU1904** for transitive `log4net 2.0.8` (via SharpPcap) — the #112 chain that **Phase 6 removes** by splitting the pcap transport out of the core. Left visible intentionally; warnings only.

## Verified locally
All four TFMs compile (`dotnet build BACnet.csproj -c Release`); full solution + **119 tests pass**.