### PR TITLE
new: split pcap Ethernet transport into BACnet.Ethernet, bump SharpPcap to 6.x

### DIFF
--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net48;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <!-- The core project lives at the repo root; sibling projects sit in their own
          folders, so keep those folders out of this project's default globs. -->
-    <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);Tests\**;Ethernet\**</DefaultItemExcludes>
     <OutputType>Library</OutputType>
     <RootNamespace>System.IO.BACnet</RootNamespace>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
@@ -31,11 +31,8 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <!-- pcap stack for the Ethernet transport (all targets; versions vary per TFM via CPM). -->
-  <ItemGroup>
-    <PackageReference Include="PacketDotNet" />
-    <PackageReference Include="SharpPcap" />
-  </ItemGroup>
+  <!-- The pcap-based Ethernet transport now lives in the BACnet.Ethernet package, so the core
+       carries no native SharpPcap/PacketDotNet dependency (issue #112). -->
 
   <!-- System.IO.Ports for the serial transports: from the BCL on net48, a package elsewhere. -->
   <ItemGroup Condition="'$(TargetFramework)' != 'net48'">

--- a/BACnet.sln
+++ b/BACnet.sln
@@ -9,6 +9,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{0AB3BF05
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BACnet.Tests", "Tests\BACnet.Tests.csproj", "{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Ethernet", "Ethernet", "{901B5B8A-C2FF-A745-7AB2-6FEEEE001F18}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BACnet.Ethernet", "Ethernet\BACnet.Ethernet.csproj", "{39192C6F-92D6-465A-BADB-C59ACDF11778}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,12 +47,25 @@ Global
 		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x64.Build.0 = Release|Any CPU
 		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x86.ActiveCfg = Release|Any CPU
 		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9}.Release|x86.Build.0 = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|x64.Build.0 = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Debug|x86.Build.0 = Debug|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|Any CPU.Build.0 = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|x64.ActiveCfg = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|x64.Build.0 = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|x86.ActiveCfg = Release|Any CPU
+		{39192C6F-92D6-465A-BADB-C59ACDF11778}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4FC9C156-8A29-4A1C-B163-06BEDE79BAD9} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{39192C6F-92D6-465A-BADB-C59ACDF11778} = {901B5B8A-C2FF-A745-7AB2-6FEEEE001F18}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {4BD775C7-0626-4B2B-969B-285F36768D4D}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,16 +9,12 @@
     <PackageVersion Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>
 
-  <!-- pcap stack. net48 pins the old API-compatible builds; every newer target shares the
-       netstandard2.0-compatible builds (consumable by net8/net10). This whole stack leaves the
-       core when the native transports are split into BACnet.Ethernet / BACnet.Serial (Phase 6). -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageVersion Include="PacketDotNet" Version="0.13.0" />
-    <PackageVersion Include="SharpPcap" Version="4.2.0" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'net48'">
-    <PackageVersion Include="PacketDotNet" Version="0.19.3" />
-    <PackageVersion Include="SharpPcap" Version="4.5.0" />
+  <!-- pcap stack for the BACnet.Ethernet package. SharpPcap 6.x targets netstandard2.0 + net8.0
+       (so a single version serves net48/ns2.0/net8/net10) and, unlike 4.x, no longer depends on the
+       vulnerable log4net — which is what let us pull it out of the core and close #112. -->
+  <ItemGroup>
+    <PackageVersion Include="PacketDotNet" Version="1.4.8" />
+    <PackageVersion Include="SharpPcap" Version="6.3.1" />
   </ItemGroup>
 
   <!-- System.IO.Ports: in the BCL for net48; a NuGet package everywhere else, versioned per runtime. -->

--- a/Ethernet/BACnet.Ethernet.csproj
+++ b/Ethernet/BACnet.Ethernet.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Concrete runtimes only (no netstandard2.0): the pcap dependencies require native libpcap
+         and PacketDotNet ships net472/net8.0/net9.0 assets but no netstandard2.0 build. The core
+         package still targets netstandard2.0 for broad managed compatibility. -->
+    <TargetFrameworks>net48;net8.0;net10.0</TargetFrameworks>
+    <RootNamespace>System.IO.BACnet</RootNamespace>
+    <Description>pcap-based BACnet/Ethernet (ISO 8802-3) transport for the BACnet library. Optional add-on that keeps the native SharpPcap/PacketDotNet dependencies out of the core package.</Description>
+    <PackageTags>bacnet;ethernet;pcap</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BACnet.csproj" />
+  </ItemGroup>
+
+  <!-- Package versions are centralised in Directory.Packages.props (CPM). -->
+  <ItemGroup>
+    <PackageReference Include="PacketDotNet" />
+    <PackageReference Include="SharpPcap" />
+  </ItemGroup>
+
+</Project>

--- a/Ethernet/BacnetTransportEthernet.cs
+++ b/Ethernet/BacnetTransportEthernet.cs
@@ -30,12 +30,10 @@
 
 namespace System.IO.BACnet;
 
-// A reference to PacketDotNet.dll & SharpPcap.dll should be made
-// in order to use this code
-// This class is not in the file BacnetTransport.cs to avoid integration 
-// of two dll when Bacnet/Ethernet is not used
+// This transport lives in its own package (BACnet.Ethernet) so the SharpPcap / PacketDotNet
+// native dependencies stay out of the pure-managed core package.
 
-internal class BacnetEthernetProtocolTransport : BacnetTransportBase
+public class BacnetEthernetProtocolTransport : BacnetTransportBase
 {
     private LibPcapLiveDevice _device;
     private byte[] _deviceMac; // Mac of the device
@@ -97,7 +95,8 @@ internal class BacnetEthernetProtocolTransport : BacnetTransportBase
 
         lock (_device)
         {
-            _device.SendPacket(buffer, dataLength + HeaderLength);
+            // SharpPcap 6.x: send the exact frame length via the span overload.
+            _device.SendPacket(buffer.AsSpan(0, dataLength + HeaderLength));
         }
 
         return dataLength + HeaderLength;
@@ -123,7 +122,7 @@ internal class BacnetEthernetProtocolTransport : BacnetTransportBase
             try
             {
                 var device = devices.FirstOrDefault(dev => dev.Interface.FriendlyName == _deviceName);
-                device?.Open(DeviceMode.Normal, 1000); // 1000 ms read timeout
+                device?.Open(DeviceModes.None, 1000); // 1000 ms read timeout
                 return device;
             }
             catch
@@ -133,7 +132,7 @@ internal class BacnetEthernetProtocolTransport : BacnetTransportBase
         }
         foreach (var device in devices)
         {
-            device.Open(DeviceMode.Normal, 1000); // 1000 ms read timeout
+            device.Open(DeviceModes.None, 1000); // 1000 ms read timeout
             if (device.LinkType == LinkLayers.Ethernet
                 && device.Interface.MacAddress != null)
                 return device;
@@ -150,8 +149,9 @@ internal class BacnetEthernetProtocolTransport : BacnetTransportBase
         {
             try
             {
-                var packet = _device.GetNextPacket();
-                if (packet != null)
+                // SharpPcap 6.x: GetNextPacket fills a PacketCapture and returns a status code
+                // (the old nullable-RawCapture return was removed).
+                if (_device.GetNextPacket(out var packet) == GetPacketStatus.PacketRead)
                     OnPacketArrival(packet);
                 else
                     Thread.Sleep(10); // NonBlockingMode, we need to slow the overhead
@@ -184,13 +184,17 @@ internal class BacnetEthernetProtocolTransport : BacnetTransportBase
         return b;
     }
 
-    private void OnPacketArrival(RawCapture packet)
+    private void OnPacketArrival(PacketCapture packet)
     {
+        // SharpPcap 6.x exposes the frame as a ReadOnlySpan<byte>; materialise it once so the
+        // existing array-based parsing (indexing + Buffer.BlockCopy) works unchanged.
+        var data = packet.Data;
+
         // don't process any packet too short to not be valid
-        if (packet.Data.Length <= 17)
+        if (data.Length <= 17)
             return;
 
-        var buffer = packet.Data;
+        var buffer = data.ToArray();
         var offset = 0;
 
         // Got frames send by me, not for me, not broadcast

--- a/Ethernet/GlobalUsings.cs
+++ b/Ethernet/GlobalUsings.cs
@@ -1,0 +1,6 @@
+global using System.Collections.Generic;
+global using System.Linq;
+global using System.Threading;
+global using PacketDotNet;
+global using SharpPcap;
+global using SharpPcap.LibPcap;

--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -1,7 +1,4 @@
 ﻿global using Common.Logging;
-global using PacketDotNet;
-global using SharpPcap;
-global using SharpPcap.LibPcap;
 global using System.Collections.Generic;
 global using System.Globalization;
 global using System.IO.BACnet.Base;


### PR DESCRIPTION
Phase 6 of the 4.0 modernization — split the native pcap transport out of the core.

**Closes #112.**

## What
Moves `BacnetTransportEthernet` out of the core into a new optional **`BACnet.Ethernet`** package (`net48;net8.0;net10.0`), so the **core package is pure-managed** with no native SharpPcap/PacketDotNet dependency.

- **Bump SharpPcap 4.x → 6.3.1** (+ PacketDotNet 1.4.8). SharpPcap 6.x **dropped its `log4net` dependency**, so the vulnerable transitive `log4net 2.0.8` (NU1902/NU1904) is gone *entirely* rather than merely relocated — this is the root cause behind #112.
- **API migration** to SharpPcap 6.x: `GetNextPacket(out PacketCapture)` + `GetPacketStatus`, `DeviceModes.None`, span-based `Data`/`SendPacket`. (PR #125 was the reference for these changes.)
- Make `BacnetEthernetProtocolTransport` **public** (was `internal`) — no base-class changes needed, its `BacnetTransportBase` members are already `protected`/`public`.
- Remove pcap `PackageReference`s and global usings from the core; exclude `Ethernet\**` from the core's globs; centralise the new versions in CPM; add `BACnet.Ethernet` to the solution.

## Notes
- `BACnet.Ethernet` targets concrete runtimes only (no netstandard2.0): PacketDotNet ships net472/net8.0/net9.0 assets but no ns2.0 build, and pcap needs native libpcap anyway. The core still targets netstandard2.0.
- **Breaking for Ethernet-transport consumers:** they now add the `BACnet.Ethernet` package (the class was previously `internal`, so this newly *exposes* it rather than removing anything usable).

## Verified locally
Core's transitive graph contains **no pcap/log4net**; all TFMs build with **no warnings**; full solution + **119 tests pass**.