### PR TITLE
new!: replace Common.Logging with Microsoft.Extensions.Logging

### DIFF
--- a/BACnet.csproj
+++ b/BACnet.csproj
@@ -21,14 +21,19 @@
 
   <!-- Package versions are centralised in Directory.Packages.props (CPM). -->
 
-  <!-- Vendor Packages -->
+  <!-- Logging abstraction (Microsoft.Extensions.Logging); providers are the consumer's choice. -->
   <ItemGroup>
-    <PackageReference Include="Common.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
-  <!-- Microsoft Packages targeting .net framework v4.8 -->
+  <!-- Microsoft.CSharp = the 'dynamic' runtime binder. A framework reference on net48, part of the
+       shared framework on net8/net10, but a package on netstandard2.0 (it used to arrive transitively
+       via Common.Logging). -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" />
   </ItemGroup>
 
   <!-- The native transports now live in their own optional packages, so the core carries no native

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -60,7 +60,7 @@ public class BacnetClient : IDisposable
     public byte ProposedWindowSize { get; set; } = 10;
     public bool ForceWindowSize { get; set; }
     public bool DefaultSegmentationHandling { get; set; } = true;
-    public ILog Log { get; set; } = LogManager.GetLogger<BacnetClient>();
+    public ILogger Log { get; set; } = BacnetLogging.CreateLogger<BacnetClient>();
 
     /// <summary>
     /// Used as the number of tentatives
@@ -168,7 +168,7 @@ public class BacnetClient : IDisposable
     {
         Transport.Start();
         Transport.MessageRecieved += OnRecieve;
-        Log.Info("Started communication");
+        Log.LogInformation("Started communication");
     }
 
     public delegate void ConfirmedServiceRequestHandler(BacnetClient sender, BacnetAddress adr, BacnetPduTypes type, BacnetConfirmedServices service, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, byte invokeId, byte[] buffer, int offset, int length);
@@ -210,7 +210,7 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug($"ConfirmedServiceRequest {service}");
+            Log.LogDebug($"ConfirmedServiceRequest {service}");
 
             raw_buffer = buffer;
             raw_length = length;
@@ -244,7 +244,7 @@ public class BacnetClient : IDisposable
                             SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.TOO_MANY_ARGUMENTS);
                             break;
                     }
-                    Log.Warn("Couldn't decode DecodeReadProperty");
+                    Log.LogWarning("Couldn't decode DecodeReadProperty");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY && OnWritePropertyRequest != null)
@@ -257,7 +257,7 @@ public class BacnetClient : IDisposable
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
                     //SendConfirmedServiceReject(adr, invokeId, BacnetRejectReason.OTHER); 
-                    Log.Warn("Couldn't decode DecodeWriteProperty");
+                    Log.LogWarning("Couldn't decode DecodeWriteProperty");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROP_MULTIPLE && OnReadPropertyMultipleRequest != null)
@@ -269,7 +269,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode DecodeReadPropertyMultiple");
+                    Log.LogWarning("Couldn't decode DecodeReadPropertyMultiple");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROP_MULTIPLE && OnWritePropertyMultipleRequest != null)
@@ -281,7 +281,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode DecodeWritePropertyMultiple");
+                    Log.LogWarning("Couldn't decode DecodeWritePropertyMultiple");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_COV_NOTIFICATION && OnCOVNotification != null)
@@ -293,7 +293,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode COVNotify");
+                    Log.LogWarning("Couldn't decode COVNotify");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_ATOMIC_WRITE_FILE && OnAtomicWriteFileRequest != null)
@@ -305,7 +305,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode AtomicWriteFile");
+                    Log.LogWarning("Couldn't decode AtomicWriteFile");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_ATOMIC_READ_FILE && OnAtomicReadFileRequest != null)
@@ -317,7 +317,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode AtomicReadFile");
+                    Log.LogWarning("Couldn't decode AtomicReadFile");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_SUBSCRIBE_COV && OnSubscribeCOV != null)
@@ -329,7 +329,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode SubscribeCOV");
+                    Log.LogWarning("Couldn't decode SubscribeCOV");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_SUBSCRIBE_COV_PROPERTY && OnSubscribeCOVProperty != null)
@@ -341,7 +341,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode SubscribeCOVProperty");
+                    Log.LogWarning("Couldn't decode SubscribeCOVProperty");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_DEVICE_COMMUNICATION_CONTROL && OnDeviceCommunicationControl != null)
@@ -354,7 +354,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode DeviceCommunicationControl");
+                    Log.LogWarning("Couldn't decode DeviceCommunicationControl");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_REINITIALIZE_DEVICE && OnReinitializedDevice != null)
@@ -367,7 +367,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode ReinitializeDevice");
+                    Log.LogWarning("Couldn't decode ReinitializeDevice");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_EVENT_NOTIFICATION && OnEventNotify != null) // F. Chaxel
@@ -381,7 +381,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode confirmed Event/Alarm Notification");
+                    Log.LogWarning("Couldn't decode confirmed Event/Alarm Notification");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_READ_RANGE && OnReadRange != null)
@@ -393,7 +393,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode ReadRange");
+                    Log.LogWarning("Couldn't decode ReadRange");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_CREATE_OBJECT && OnCreateObjectRequest != null)
@@ -405,7 +405,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode CreateObject");
+                    Log.LogWarning("Couldn't decode CreateObject");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_DELETE_OBJECT && OnDeleteObjectRequest != null)
@@ -417,7 +417,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode DecodeDeleteObject");
+                    Log.LogWarning("Couldn't decode DecodeDeleteObject");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_GET_ALARM_SUMMARY && OnGetAlarmSummaryOrEventInformation != null)
@@ -437,7 +437,7 @@ public class BacnetClient : IDisposable
                         // DAL
                         SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                         //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                        Log.Warn("Couldn't decode GetAlarmSummary");
+                        Log.LogWarning("Couldn't decode GetAlarmSummary");
                     }
 #else
                 SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
@@ -457,7 +457,7 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode GetEventInformation");
+                    Log.LogWarning("Couldn't decode GetEventInformation");
                 }
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_ACKNOWLEDGE_ALARM && OnAlarmAcknowledge != null)
@@ -472,14 +472,14 @@ public class BacnetClient : IDisposable
                     // DAL
                     SendAbort(address, invokeId, BacnetAbortReason.OTHER);
                     //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-                    Log.Warn("Couldn't decode AlarmAcknowledge");
+                    Log.LogWarning("Couldn't decode AlarmAcknowledge");
                 }
             }
             else
             {
                 // DAL
                 SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
-                Log.Debug($"Confirmed service not handled: {service}");
+                Log.LogDebug($"Confirmed service not handled: {service}");
             }
         }
         catch (Exception ex)
@@ -487,7 +487,7 @@ public class BacnetClient : IDisposable
             // DAL
             SendAbort(address, invokeId, BacnetAbortReason.OTHER);
             //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_DEVICE, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
-            Log.Error("Error in ProcessConfirmedServiceRequest", ex);
+            Log.LogError(ex, "Error in ProcessConfirmedServiceRequest");
         }
     }
 
@@ -510,21 +510,21 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug("UnconfirmedServiceRequest");
+            Log.LogDebug("UnconfirmedServiceRequest");
             OnUnconfirmedServiceRequest?.Invoke(this, address, type, service, buffer, offset, length);
             if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_I_AM && OnIam != null)
             {
                 if (Services.DecodeIamBroadcast(buffer, offset, out var deviceId, out var maxAdpu, out var segmentation, out var vendorId) >= 0)
                     OnIam(this, address, deviceId, maxAdpu, segmentation, vendorId);
                 else
-                    Log.Warn("Couldn't decode IamBroadcast");
+                    Log.LogWarning("Couldn't decode IamBroadcast");
             }
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_WHO_IS && OnWhoIs != null)
             {
                 if (Services.DecodeWhoIsBroadcast(buffer, offset, length, out var lowLimit, out var highLimit) >= 0)
                     OnWhoIs(this, address, lowLimit, highLimit);
                 else
-                    Log.Warn("Couldn't decode WhoIsBroadcast");
+                    Log.LogWarning("Couldn't decode WhoIsBroadcast");
             }
             // added by thamersalek
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_WHO_HAS && OnWhoHas != null)
@@ -532,45 +532,45 @@ public class BacnetClient : IDisposable
                 if (Services.DecodeWhoHasBroadcast(buffer, offset, length, out var lowLimit, out var highLimit, out var objId, out var objName) >= 0)
                     OnWhoHas(this, address, lowLimit, highLimit, objId, objName);
                 else
-                    Log.Warn("Couldn't decode WhoHasBroadcast");
+                    Log.LogWarning("Couldn't decode WhoHasBroadcast");
             }
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_COV_NOTIFICATION && OnCOVNotification != null)
             {
                 if (Services.DecodeCOVNotifyUnconfirmed(address, buffer, offset, length, out var subscriberProcessIdentifier, out var initiatingDeviceIdentifier, out var monitoredObjectIdentifier, out var timeRemaining, out var values) >= 0)
                     OnCOVNotification(this, address, 0, subscriberProcessIdentifier, initiatingDeviceIdentifier, monitoredObjectIdentifier, timeRemaining, false, values, BacnetMaxSegments.MAX_SEG0);
                 else
-                    Log.Warn("Couldn't decode COVNotifyUnconfirmed");
+                    Log.LogWarning("Couldn't decode COVNotifyUnconfirmed");
             }
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION && OnTimeSynchronize != null)
             {
                 if (Services.DecodeTimeSync(buffer, offset, length, out var dateTime) >= 0)
                     OnTimeSynchronize(this, address, dateTime, false);
                 else
-                    Log.Warn("Couldn't decode TimeSynchronize");
+                    Log.LogWarning("Couldn't decode TimeSynchronize");
             }
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION && OnTimeSynchronize != null)
             {
                 if (Services.DecodeTimeSync(buffer, offset, length, out var dateTime) >= 0)
                     OnTimeSynchronize(this, address, dateTime, true);
                 else
-                    Log.Warn("Couldn't decode TimeSynchronize");
+                    Log.LogWarning("Couldn't decode TimeSynchronize");
             }
             else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_EVENT_NOTIFICATION && OnEventNotify != null) // F. Chaxel
             {
                 if (Services.DecodeEventNotifyData(buffer, offset, length, out var eventData) >= 0)
                     OnEventNotify(this, address, 0, eventData, false);
                 else
-                    Log.Warn("Couldn't decode unconfirmed Event/Alarm Notification");
+                    Log.LogWarning("Couldn't decode unconfirmed Event/Alarm Notification");
             }
             else
             {
-                Log.Debug($"Unconfirmed service not handled: {service}");
+                Log.LogDebug($"Unconfirmed service not handled: {service}");
                 // SendUnConfirmedServiceReject(adr); ? exists ?
             }
         }
         catch (Exception ex)
         {
-            Log.Error("Error in ProcessUnconfirmedServiceRequest", ex);
+            Log.LogError(ex, "Error in ProcessUnconfirmedServiceRequest");
         }
     }
 
@@ -581,12 +581,12 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug($"Received SimpleAck for {service}");
+            Log.LogDebug($"Received SimpleAck for {service}");
             OnSimpleAck?.Invoke(this, adr, type, service, invokeId, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error("Error in ProcessSimpleAck", ex);
+            Log.LogError(ex, "Error in ProcessSimpleAck");
         }
     }
 
@@ -597,12 +597,12 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug($"Received ComplexAck for {service}");
+            Log.LogDebug($"Received ComplexAck for {service}");
             OnComplexAck?.Invoke(this, adr, type, service, invokeId, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error($"Error in {nameof(ProcessComplexAck)}", ex);
+            Log.LogError(ex, $"Error in {nameof(ProcessComplexAck)}");
         }
     }
 
@@ -615,16 +615,16 @@ public class BacnetClient : IDisposable
         {
             if (Services.DecodeError(buffer, offset, out var errorClass, out var errorCode) < 0)
             {
-                Log.Warn("Couldn't decode received Error");
+                Log.LogWarning("Couldn't decode received Error");
                 return;
             }
 
-            Log.Debug($"Received Error {errorClass} {errorCode}");
+            Log.LogDebug($"Received Error {errorClass} {errorCode}");
             OnError?.Invoke(this, adr, type, service, invokeId, errorClass, errorCode, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error($"Error in {nameof(ProcessError)}", ex);
+            Log.LogError(ex, $"Error in {nameof(ProcessError)}");
         }
     }
 
@@ -635,12 +635,12 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug($"Received Abort, reason: {reason}");
+            Log.LogDebug($"Received Abort, reason: {reason}");
             OnAbort?.Invoke(this, adr, type, invokeId, reason, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error("Error in ProcessAbort", ex);
+            Log.LogError(ex, "Error in ProcessAbort");
         }
     }
 
@@ -651,12 +651,12 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug($"Received Reject, reason: {reason}");
+            Log.LogDebug($"Received Reject, reason: {reason}");
             OnReject?.Invoke(this, adr, type, invokeId, reason, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error("Error in ProcessReject", ex);
+            Log.LogError(ex, "Error in ProcessReject");
         }
     }
 
@@ -667,12 +667,12 @@ public class BacnetClient : IDisposable
     {
         try
         {
-            Log.Debug("Received SegmentAck");
+            Log.LogDebug("Received SegmentAck");
             OnSegmentAck?.Invoke(this, adr, type, originalInvokeId, sequenceNumber, actualWindowSize, buffer, offset, length);
         }
         catch (Exception ex)
         {
-            Log.Error("Error in ProcessSegmentAck", ex);
+            Log.LogError(ex, "Error in ProcessSegmentAck");
         }
     }
 
@@ -692,7 +692,7 @@ public class BacnetClient : IDisposable
         byte invokeId, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, bool server, byte sequenceNumber,
         byte proposedWindowNumber, byte[] buffer, int offset, int length)
     {
-        Log.Trace($@"Processing Segment #{sequenceNumber} of invoke-id #{invokeId}");
+        Log.LogTrace($@"Processing Segment #{sequenceNumber} of invoke-id #{invokeId}");
 
         if (!_segmentsPerInvokeId.ContainsKey(invokeId))
             _segmentsPerInvokeId[invokeId] = new List<Tuple<byte, byte[]>>();
@@ -866,7 +866,7 @@ public class BacnetClient : IDisposable
                 break;
 
             default:
-                Log.Warn($"Something else arrived: {type}");
+                Log.LogWarning($"Something else arrived: {type}");
                 break;
         }
     }
@@ -1014,7 +1014,7 @@ public class BacnetClient : IDisposable
 
             if (npduFunction.HasFlag(BacnetNpduControls.NetworkLayerMessage))
             {
-                Log.Info("Network Layer message received");
+                Log.LogInformation("Network Layer message received");
                 // DAL
                 ProcessNetworkMessage(remoteAddress, npduFunction, npduMessageType, buffer, offset, msgLength);
                 return;
@@ -1028,7 +1028,7 @@ public class BacnetClient : IDisposable
         }
         catch (Exception ex)
         {
-            Log.Error("Error in OnRecieve", ex);
+            Log.LogError(ex, "Error in OnRecieve");
         }
     }
 
@@ -1052,13 +1052,13 @@ public class BacnetClient : IDisposable
             }
 
             if (sent)
-                Log.Debug($"Sending Register as a Foreign Device to {bbmdIp}");
+                Log.LogDebug($"Sending Register as a Foreign Device to {bbmdIp}");
             else
-                Log.Warn("The given address do not match with the IP version");
+                Log.LogWarning("The given address do not match with the IP version");
         }
         catch (Exception ex)
         {
-            Log.Error("Error on RegisterAsForeignDevice (Wrong Transport, not IP ?)", ex);
+            Log.LogError(ex, "Error on RegisterAsForeignDevice (Wrong Transport, not IP ?)");
         }
     }
 
@@ -1088,13 +1088,13 @@ public class BacnetClient : IDisposable
             }
 
             if (sent)
-                Log.Debug($"Sending Remote Whois to {bbmdIP}");
+                Log.LogDebug($"Sending Remote Whois to {bbmdIP}");
             else
-                Log.Warn("The given address do not match with the IP version");
+                Log.LogWarning("The given address do not match with the IP version");
         }
         catch (Exception ex)
         {
-            Log.Error("Error on Sending Whois to remote BBMD (Wrong Transport, not IP ?)", ex);
+            Log.LogError(ex, "Error on Sending Whois to remote BBMD (Wrong Transport, not IP ?)");
         }
 
     }
@@ -1106,11 +1106,11 @@ public class BacnetClient : IDisposable
             // _receiver could be an unicast @ : for direct acces 
             // usefull on BIP for a known IP:Port, unknown device Id
             receiver = Transport.GetBroadcastAddress();
-            Log.Debug("Broadcasting WhoIs");
+            Log.LogDebug("Broadcasting WhoIs");
         }
         else
         {
-            Log.Debug($"Sending WhoIs to {receiver}");
+            Log.LogDebug($"Sending WhoIs to {receiver}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1126,11 +1126,11 @@ public class BacnetClient : IDisposable
         if (receiver == null)
         {
             receiver = Transport.GetBroadcastAddress();
-            Log.Debug($"Broadcasting Iam {deviceId}");
+            Log.LogDebug($"Broadcasting Iam {deviceId}");
         }
         else
         {
-            Log.Debug($"Sending Iam {deviceId} to {receiver}");
+            Log.LogDebug($"Sending Iam {deviceId} to {receiver}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1156,11 +1156,11 @@ public class BacnetClient : IDisposable
         if (receiver == null)
         {
             receiver = Transport.GetBroadcastAddress();
-            Log.Debug($"Broadcasting WhoHas {objId?.ToString() ?? objName}");
+            Log.LogDebug($"Broadcasting WhoHas {objId?.ToString() ?? objName}");
         }
         else
         {
-            Log.Debug($"Sending WhoHas {objId?.ToString() ?? objName} to {receiver}");
+            Log.LogDebug($"Sending WhoHas {objId?.ToString() ?? objName} to {receiver}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1174,7 +1174,7 @@ public class BacnetClient : IDisposable
     // ReSharper disable once InconsistentNaming
     public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source = null)
     {
-        Log.Debug($"Broadcasting IHave {objName} {objId}");
+        Log.LogDebug($"Broadcasting IHave {objName} {objId}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
         var broadcast = Transport.GetBroadcastAddress();
@@ -1187,7 +1187,7 @@ public class BacnetClient : IDisposable
 
     public void SendUnconfirmedEventNotification(BacnetAddress adr, BacnetEventNotificationData eventData, BacnetAddress source = null)
     {
-        Log.Debug($"Sending Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
+        Log.LogDebug($"Sending Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
@@ -1198,7 +1198,7 @@ public class BacnetClient : IDisposable
 
     public void SendConfirmedServiceReject(BacnetAddress adr, byte invokeId, BacnetRejectReason reason)
     {
-        Log.Debug($"Sending Service reject: {reason}");
+        Log.LogDebug($"Sending Service reject: {reason}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
 
@@ -1210,7 +1210,7 @@ public class BacnetClient : IDisposable
     public void SendAbort(BacnetAddress adr, byte invokeId, BacnetAbortReason reason)
     {
         // DAL
-        Log.Debug($"Sending Service reject: {reason}");
+        Log.LogDebug($"Sending Service reject: {reason}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
 
@@ -1221,7 +1221,7 @@ public class BacnetClient : IDisposable
 
     public void SynchronizeTime(BacnetAddress adr, DateTime dateTime, BacnetAddress source = null)
     {
-        Log.Debug($"Sending Time Synchronize: {dateTime} {dateTime.Kind.ToString().ToUpper()}");
+        Log.LogDebug($"Sending Time Synchronize: {dateTime} {dateTime.Kind.ToString().ToUpper()}");
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr, source);
@@ -1300,7 +1300,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWriteFileRequest(BacnetAddress adr, BacnetObjectId objectId, int position, int count, byte[] fileBuffer, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending AtomicWriteFileRequest");
+        Log.LogDebug("Sending AtomicWriteFileRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1339,7 +1339,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadFileRequest(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending AtomicReadFileRequest");
+        Log.LogDebug("Sending AtomicReadFileRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1420,7 +1420,7 @@ public class BacnetClient : IDisposable
 
     private IAsyncResult BeginReadRangeRequestCore(BacnetAddress adr, BacnetObjectId objectId, BacnetReadRangeRequestTypes bacnetReadRangeRequestTypes, DateTime readFrom, uint idxBegin, uint quantity, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending ReadRangeRequest");
+        Log.LogDebug("Sending ReadRangeRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1526,7 +1526,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginSubscribeCOVRequest(BacnetAddress adr, BacnetObjectId objectId, uint subscribeId, bool cancel, bool issueConfirmedNotifications, uint lifetime, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug($"Sending SubscribeCOVRequest {objectId}");
+        Log.LogDebug($"Sending SubscribeCOVRequest {objectId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1573,7 +1573,7 @@ public class BacnetClient : IDisposable
     // DAL
     public IAsyncResult BeginSendConfirmedEventNotificationRequest(BacnetAddress adr, BacnetEventNotificationData eventData, bool waitForTransmit, byte invokeId = 0, BacnetAddress source = null)
     {
-        Log.Debug($"Sending Confirmed Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
+        Log.LogDebug($"Sending Confirmed Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1622,7 +1622,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginSubscribePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference monitoredProperty, uint subscribeId, bool cancel, bool issueConfirmedNotifications, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug($"Sending SubscribePropertyRequest {objectId}.{monitoredProperty}");
+        Log.LogDebug($"Sending SubscribePropertyRequest {objectId}.{monitoredProperty}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1690,7 +1690,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadPropertyRequest(BacnetAddress address, BacnetObjectId objectId, BacnetPropertyIds propertyId, bool waitForTransmit, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
-        Log.Debug($"Sending ReadPropertyRequest {objectId} {propertyId}");
+        Log.LogDebug($"Sending ReadPropertyRequest {objectId} {propertyId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1776,7 +1776,7 @@ public class BacnetClient : IDisposable
         if (priority.HasValue && (priority < 1 || priority > 16))
             throw new ArgumentOutOfRangeException(nameof(priority), "WritePropertyRequest priority must be between 1 and 16");
 
-        Log.Debug($"Sending WritePropertyRequest {objectId} {propertyId}");
+        Log.LogDebug($"Sending WritePropertyRequest {objectId} {propertyId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1794,7 +1794,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWritePropertyMultipleRequest(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug($"Sending WritePropertyMultipleRequest {objectId}");
+        Log.LogDebug($"Sending WritePropertyMultipleRequest {objectId}");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
@@ -1845,7 +1845,7 @@ public class BacnetClient : IDisposable
     public IAsyncResult BeginWritePropertyMultipleRequest(BacnetAddress adr, ICollection<BacnetReadAccessResult> valueList, bool waitForTransmit, byte invokeId = 0)
     {
         var objectIds = string.Join(", ", valueList.Select(v => v.objectIdentifier));
-        Log.Debug($"Sending WritePropertyMultipleRequest {objectIds}");
+        Log.LogDebug($"Sending WritePropertyMultipleRequest {objectIds}");
 
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1910,7 +1910,7 @@ public class BacnetClient : IDisposable
     public IAsyncResult BeginReadPropertyMultipleRequest(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, bool waitForTransmit, byte invokeId = 0)
     {
         var propertyIds = string.Join(", ", propertyIdAndArrayIndex.Select(v => (BacnetPropertyIds)v.propertyIdentifier));
-        Log.Debug($"Sending ReadPropertyMultipleRequest {objectId} {propertyIds}");
+        Log.LogDebug($"Sending ReadPropertyMultipleRequest {objectId} {propertyIds}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1951,7 +1951,7 @@ public class BacnetClient : IDisposable
     public IAsyncResult BeginReadPropertyMultipleRequest(BacnetAddress adr, IList<BacnetReadAccessSpecification> properties, bool waitForTransmit, byte invokeId = 0)
     {
         var objectIds = string.Join(", ", properties.Select(v => v.objectIdentifier));
-        Log.Debug($"Sending ReadPropertyMultipleRequest {objectIds}");
+        Log.LogDebug($"Sending ReadPropertyMultipleRequest {objectIds}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2018,7 +2018,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginCreateObjectRequest(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending CreateObjectRequest");
+        Log.LogDebug("Sending CreateObjectRequest");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
@@ -2067,7 +2067,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginDeleteObjectRequest(BacnetAddress adr, BacnetObjectId objectId, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending DeleteObjectRequest");
+        Log.LogDebug("Sending DeleteObjectRequest");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
@@ -2140,7 +2140,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginRemoveListElementRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending RemoveListElementRequest");
+        Log.LogDebug("Sending RemoveListElementRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2158,7 +2158,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginAddListElementRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug($"Sending AddListElementRequest {objectId} {(BacnetPropertyIds)reference.propertyIdentifier}");
+        Log.LogDebug($"Sending AddListElementRequest {objectId} {(BacnetPropertyIds)reference.propertyIdentifier}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2212,7 +2212,7 @@ public class BacnetClient : IDisposable
     // Fc
     public IAsyncResult BeginRawEncodedDecodedPropertyConfirmedRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, BacnetConfirmedServices serviceId, byte[] inOutBuffer, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending RawEncodedRequest");
+        Log.LogDebug("Sending RawEncodedRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2294,7 +2294,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginDeviceCommunicationControlRequest(BacnetAddress adr, uint timeDuration, uint enableDisable, string password, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending DeviceCommunicationControlRequest");
+        Log.LogDebug("Sending DeviceCommunicationControlRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2357,7 +2357,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginGetAlarmSummaryOrEventRequest(BacnetAddress adr, bool getEvent, IList<BacnetGetEventInformationData> alarms, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending Alarm summary request");
+        Log.LogDebug("Sending Alarm summary request");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2439,7 +2439,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginAlarmAcknowledgement(BacnetAddress adr, BacnetObjectId objId, BacnetEventStates eventState, string ackText, BacnetGenericTime evTimeStamp, BacnetGenericTime ackTimeStamp, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending AlarmAcknowledgement");
+        Log.LogDebug("Sending AlarmAcknowledgement");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2483,7 +2483,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReinitializeRequest(BacnetAddress adr, BacnetReinitializedStates state, string password, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending ReinitializeRequest");
+        Log.LogDebug("Sending ReinitializeRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2511,7 +2511,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginConfirmedNotify(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, IList<BacnetPropertyValue> values, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug("Sending Notify (confirmed)");
+        Log.LogDebug("Sending Notify (confirmed)");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
@@ -2538,7 +2538,7 @@ public class BacnetClient : IDisposable
     {
         if (!issueConfirmedNotifications)
         {
-            Log.Debug("Sending Notify (unconfirmed)");
+            Log.LogDebug("Sending Notify (unconfirmed)");
             var buffer = GetEncodeBuffer(Transport.HeaderLength);
             NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
             APDU.EncodeUnconfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_COV_NOTIFICATION);
@@ -2588,7 +2588,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginLifeSafetyOperationRequest(BacnetAddress address, BacnetObjectId objectId, uint processId, string requestingSrc, BacnetLifeSafetyOperations operation, bool waitForTransmit, byte invokeId = 0)
     {
-        Log.Debug($"Sending {ToTitleCase(operation)} {objectId}");
+        Log.LogDebug($"Sending {ToTitleCase(operation)} {objectId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2744,7 +2744,7 @@ public class BacnetClient : IDisposable
                 {
                     if (!WaitForAllTransmits(TransmitTimeout))
                     {
-                        Log.Warn("Transmit timeout");
+                        Log.LogWarning("Transmit timeout");
                         break;
                     }
 
@@ -2752,13 +2752,13 @@ public class BacnetClient : IDisposable
 
                     if (!WaitForSegmentAck(adr, invokeId, segmentation, Timeout))
                     {
-                        Log.Warn("Didn't get segmentACK");
+                        Log.LogWarning("Didn't get segmentACK");
                         break;
                     }
 
                     if (segmentation.sequence_number != currentNumber)
                     {
-                        Log.Debug("Oh, a retransmit");
+                        Log.LogDebug("Oh, a retransmit");
                         moreFollows = true;
                     }
                 }
@@ -2769,7 +2769,7 @@ public class BacnetClient : IDisposable
                     WaitForSegmentAck(adr, invokeId, segmentation, 0); // don't wait
 
                         if (segmentation.sequence_number != currentNumber)
-                        Log.Debug("Oh, a retransmit");
+                        Log.LogDebug("Oh, a retransmit");
                 }
 
                 if (moreFollows)
@@ -2785,7 +2785,7 @@ public class BacnetClient : IDisposable
 
     private void SendComplexAck(BacnetAddress adr, byte invokeId, Segmentation segmentation, BacnetConfirmedServices service, Action<EncodeBuffer> apduContentEncode)
     {
-        Log.Debug($"Sending {ToTitleCase(service)}");
+        Log.LogDebug($"Sending {ToTitleCase(service)}");
 
         //encode
         if (EncodeSegment(adr, invokeId, segmentation, service, out var buffer, apduContentEncode))
@@ -2793,7 +2793,7 @@ public class BacnetClient : IDisposable
             //client doesn't support segments
             if (segmentation == null)
             {
-                Log.Info("Segmentation denied");
+                Log.LogInformation("Segmentation denied");
                 // DAL
                 SendAbort(adr, invokeId, BacnetAbortReason.SEGMENTATION_NOT_SUPPORTED);
                 //ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
@@ -2806,14 +2806,14 @@ public class BacnetClient : IDisposable
             {
                 if (segmentation.max_segments != 0xFF && segmentation.buffer.offset > segmentation.max_segments * (GetMaxApdu() - 5))      //5 is adpu header
                 {
-                    Log.Info("Too much segmenation");
+                    Log.LogInformation("Too much segmenation");
                     // DAL
                     SendAbort(adr, invokeId, BacnetAbortReason.APDU_TOO_LONG);
                     //ErrorResponse(adr, service, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES, BacnetErrorCodes.ERROR_CODE_ABORT_APDU_TOO_LONG);
                     buffer.result = EncodeResult.Good;     //don't continue the segmentation
                     return;
                 }
-                Log.Debug("Segmentation required");
+                Log.LogDebug("Segmentation required");
             }
 
             //increment before ack can do so (race condition)
@@ -2889,7 +2889,7 @@ public class BacnetClient : IDisposable
 
     public void ErrorResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode)
     {
-        Log.Debug($"Sending ErrorResponse for {service}: {errorCode}");
+        Log.LogDebug($"Sending ErrorResponse for {service}: {errorCode}");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR, service, invokeId);
@@ -2899,7 +2899,7 @@ public class BacnetClient : IDisposable
 
     public void SimpleAckResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId)
     {
-        Log.Debug($"Sending SimpleAckResponse for {service}");
+        Log.LogDebug($"Sending SimpleAckResponse for {service}");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeSimpleAck(buffer, BacnetPduTypes.PDU_TYPE_SIMPLE_ACK, service, invokeId);
@@ -2908,7 +2908,7 @@ public class BacnetClient : IDisposable
 
     public void SegmentAckResponse(BacnetAddress adr, bool negative, bool server, byte originalInvokeId, byte sequenceNumber, byte actualWindowSize)
     {
-        Log.Debug("Sending SegmentAckResponse");
+        Log.LogDebug("Sending SegmentAckResponse");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeSegmentAck(buffer, BacnetPduTypes.PDU_TYPE_SEGMENT_ACK | (negative ? BacnetPduTypes.NEGATIVE_ACK : 0) | (server ? BacnetPduTypes.SERVER : 0), originalInvokeId, sequenceNumber, actualWindowSize);

--- a/BacnetLogging.cs
+++ b/BacnetLogging.cs
@@ -1,0 +1,24 @@
+namespace System.IO.BACnet;
+
+/// <summary>
+/// Global entry point for wiring Microsoft.Extensions.Logging into the BACnet stack.
+/// <para>
+/// The stack is instantiated directly (not through a DI container), so it reads its logger factory
+/// from here. Assign <see cref="Factory"/> once at start-up — e.g.
+/// <c>BacnetLogging.Factory = LoggerFactory.Create(b =&gt; b.AddConsole());</c> — and every
+/// <see cref="BacnetClient"/>, transport and BVLC layer created afterwards logs through it.
+/// Individual instances can still override their <c>Log</c> property directly.
+/// </para>
+/// <para>Defaults to <see cref="NullLoggerFactory"/>, so logging is a no-op until configured.</para>
+/// </summary>
+public static class BacnetLogging
+{
+    /// <summary>The factory used to create default loggers for newly-created stack objects.</summary>
+    public static ILoggerFactory Factory { get; set; } = NullLoggerFactory.Instance;
+
+    /// <summary>Creates a logger categorised by <typeparamref name="T"/> from <see cref="Factory"/>.</summary>
+    public static ILogger CreateLogger<T>() => Factory.CreateLogger(typeof(T).FullName ?? typeof(T).Name);
+
+    /// <summary>Creates a logger categorised by <paramref name="type"/> from <see cref="Factory"/>.</summary>
+    public static ILogger CreateLogger(Type type) => Factory.CreateLogger(type.FullName ?? type.Name);
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,8 @@
 
   <!-- Core dependencies -->
   <ItemGroup>
-    <PackageVersion Include="Common.Logging" Version="3.4.1" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <!-- pcap stack for the BACnet.Ethernet package (net48/net8.0/net10.0). SharpPcap 6.x, unlike the

--- a/GlobalUsings.cs
+++ b/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using Common.Logging;
+﻿global using Microsoft.Extensions.Logging;
+global using Microsoft.Extensions.Logging.Abstractions;
 global using System.Collections.Generic;
 global using System.Globalization;
 global using System.IO.BACnet.Base;

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,85 @@
+# Upgrading to BACnet 4.0
+
+This guide covers the breaking changes in 4.0 and how to adapt your code.
+
+## Logging: `Common.Logging` → `Microsoft.Extensions.Logging`
+
+The library no longer depends on the unmaintained `Common.Logging`. It now uses the standard
+**`Microsoft.Extensions.Logging`** abstractions, so BACnet logs flow through the same pipeline as
+the rest of a modern .NET application.
+
+The public `Log` property on `BacnetClient`, `BVLC`, `BVLCV6` and every transport changed type:
+
+```diff
+- public Common.Logging.ILog Log { get; set; }
++ public Microsoft.Extensions.Logging.ILogger Log { get; set; }
+```
+
+By default logging is a **no-op** (`NullLogger`), so if you never configured logging there is nothing
+to do. To route BACnet logs somewhere, pick one of the following.
+
+### Option 1 — configure once (recommended)
+
+Assign an `ILoggerFactory` to `BacnetLogging.Factory` at start-up. Every `BacnetClient`, transport and
+BVLC layer created afterwards logs through it:
+
+```csharp
+using Microsoft.Extensions.Logging;
+using System.IO.BACnet;
+
+BacnetLogging.Factory = LoggerFactory.Create(builder => builder.AddConsole());
+
+var client = new BacnetClient(new BacnetIpUdpProtocolTransport(0xBAC0));
+client.Start(); // logs now go to the console
+```
+
+### Option 2 — per instance
+
+Assign any `ILogger` directly. Only the *type* you pass changes versus 3.x:
+
+```csharp
+var loggerFactory = LoggerFactory.Create(b => b.AddConsole());
+var client = new BacnetClient(transport) { Log = loggerFactory.CreateLogger<BacnetClient>() };
+```
+
+### Provider examples
+
+`Microsoft.Extensions.Logging` has providers for every common sink. Wire them into the factory:
+
+```csharp
+// Serilog        (package: Serilog.Extensions.Logging + a Serilog sink)
+BacnetLogging.Factory = LoggerFactory.Create(b => b.AddSerilog(Log.Logger));
+
+// NLog           (package: NLog.Extensions.Logging)
+BacnetLogging.Factory = LoggerFactory.Create(b => b.AddNLog());
+
+// log4net        (package: Microsoft.Extensions.Logging.Log4Net.AspNetCore — works in any app)
+BacnetLogging.Factory = LoggerFactory.Create(b => b.AddLog4Net("log4net.config"));
+```
+
+> **Already using `Common.Logging`?** An optional `BACnet.Logging.CommonLogging` bridge package
+> (forwarding `ILogger` to `Common.Logging`) will let you keep your existing sinks with a couple of
+> lines. Until then, the log4net/Serilog/NLog providers above cover most setups.
+
+## Native transports are now separate packages
+
+The pcap and serial transports moved out of the core package so the core is pure-managed with no
+native dependencies. Add the package you need:
+
+| Transport | Package | Notes |
+|-----------|---------|-------|
+| Ethernet (pcap) | **`BACnet.Ethernet`** | `BacnetEthernetProtocolTransport` (now `public`); needs libpcap/Npcap. |
+| Serial / MS-TP / PTP | **`BACnet.Serial`** | `BacnetSerialPortTransport` (the `System.IO.Ports` implementation). |
+
+The `(portName, baudRate, …)` convenience constructors on `BacnetMstpProtocolTransport` and
+`BacnetPtpProtocolTransport` moved to factory helpers in `BACnet.Serial`:
+
+```diff
+- var mstp = new BacnetMstpProtocolTransport("COM1", 38400);
++ var mstp = SerialTransport.Mstp("COM1", 38400);          // from the BACnet.Serial package
+  // or pass your own IBacnetSerialTransport to the (unchanged) core constructor:
+  var mstp2 = new BacnetMstpProtocolTransport(new BacnetSerialPortTransport("COM1", 38400));
+```
+
+The core still contains the MS/TP and PTP protocol logic and the `IBacnetSerialTransport` abstraction;
+only the physical `SerialPort` implementation moved.

--- a/Serialize/BVLC.cs
+++ b/Serialize/BVLC.cs
@@ -22,7 +22,7 @@ public class BVLC
     // If empty it's equal to *.*.*.*, everyone allows
     private readonly List<Regex> _autorizedFdr = new();
 
-    public ILog Log { get; set; } = LogManager.GetLogger<BVLC>();
+    public ILogger Log { get; set; } = BacnetLogging.CreateLogger<BVLC>();
 
     public BVLC(BacnetIpUdpProtocolTransport transport)
     {
@@ -84,7 +84,7 @@ public class BVLC
                     return;
                 }
             }
-            Log.Info($"Rejected FDR registration, IP : {sender.Address}");
+            Log.LogInformation($"Rejected FDR registration, IP : {sender.Address}");
         }
     }
 

--- a/Transport/BVLCV6.cs
+++ b/Transport/BVLCV6.cs
@@ -21,7 +21,7 @@ public class BVLCV6
     public bool RandomVmac;
 
     public byte[] VMAC = new byte[3];
-    public ILog Log { get; set; } = LogManager.GetLogger<BVLCV6>();
+    public ILogger Log { get; set; } = BacnetLogging.CreateLogger<BVLCV6>();
 
     public BVLCV6(BacnetIpV6UdpProtocolTransport transport, int vMac)
     {
@@ -89,7 +89,7 @@ public class BVLCV6
                 return;
             }
 
-            Log.Info($"Rejected FDR registration, IP : {sender.Address}");
+            Log.LogInformation($"Rejected FDR registration, IP : {sender.Address}");
         }
     }
 

--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -100,7 +100,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
                 DisableConnReset(_sharedConn);
                 _sharedConn.Client.Bind(ep);
                 SetDontFragment(_sharedConn, _dontFragment);
-                Log.Info($"Binded shared {ep} using UDP");
+                Log.LogInformation($"Binded shared {ep} using UDP");
             }
             /* This is our own exclusive port. We'll recieve everything sent to this. */
             /* So this is how we'll present our selves to the world */
@@ -135,7 +135,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
             _exclusiveConn.Client.Bind(ep);
             SetDontFragment(_exclusiveConn, _dontFragment);
             _exclusiveConn.EnableBroadcast = true;
-            Log.Info($"Binded exclusively to {ep} using UDP");
+            Log.LogInformation($"Binded exclusively to {ep} using UDP");
         }
 
         Bvlc = new BVLC(this);
@@ -164,7 +164,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
         }
         catch (SocketException e)
         {
-            Log.WarnFormat("Unable to set DontFragment", e);
+            Log.LogWarning(e, "Unable to set DontFragment");
         }
     }
 
@@ -235,7 +235,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
                         }
                         catch (Exception ex)
                         {
-                            transport.Log.Error($"Failed to restart data receive. {ex}");
+                            transport.Log.LogError($"Failed to restart data receive. {ex}");
                         }
                     }, (this, connection));
                 }
@@ -251,7 +251,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
 
             if (receivedLength < BVLC.BVLC_HEADER_LENGTH)
             {
-                Log.Warn($"Some garbage data got in: {ConvertToHex(receiveBuffer)}");
+                Log.LogWarning($"Some garbage data got in: {ConvertToHex(receiveBuffer)}");
                 return;
             }
 
@@ -260,7 +260,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
 
             if (headerLength == -1)
             {
-                Log.Warn($"Unknow BVLC Header in: {ConvertToHex(receiveBuffer)}");
+                Log.LogWarning($"Unknow BVLC Header in: {ConvertToHex(receiveBuffer)}");
                 return;
             }
 
@@ -269,7 +269,7 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
                 case BacnetBvlcFunctions.BVLC_RESULT:
                     // response to BVLC_REGISTER_FOREIGN_DEVICE, could be BVLC_DISTRIBUTE_BROADCAST_TO_NETWORK
                     // but we are not a BBMD, we don't care
-                    Log.Debug("Receive Register as Foreign Device Response");
+                    Log.LogDebug("Receive Register as Foreign Device Response");
                     break;
 
                 case BacnetBvlcFunctions.BVLC_FORWARDED_NPDU:
@@ -287,13 +287,13 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
                 function != BacnetBvlcFunctions.BVLC_ORIGINAL_BROADCAST_NPDU &&
                 function != BacnetBvlcFunctions.BVLC_FORWARDED_NPDU)
             {
-                Log.Debug($"{function} - ignoring");
+                Log.LogDebug($"{function} - ignoring");
                 return;
             }
 
             if (receivedLength <= headerLength)
             {
-                Log.Warn($"Missing data, only header received: {ConvertToHex(receiveBuffer)}");
+                Log.LogWarning($"Missing data, only header received: {ConvertToHex(receiveBuffer)}");
                 return;
             }
 
@@ -301,14 +301,14 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
         }
         catch (ObjectDisposedException)
         {
-            Log.Debug("Connection has been disposed");
+            Log.LogDebug("Connection has been disposed");
         }
         catch (Exception e)
         {
             if (connection.Client == null || _disposing)
                 return;
 
-            Log.Error("Exception in OnRecieveData", e);
+            Log.LogError(e, "Exception in OnRecieveData");
         }
     }
 

--- a/Transport/BacnetIpV6UdpProtocolTransport.cs
+++ b/Transport/BacnetIpV6UdpProtocolTransport.cs
@@ -235,7 +235,7 @@ public class BacnetIpV6UdpProtocolTransport : BacnetTransportBase
                 Convert(ep, out var remoteAddress);
                 if (rx < BVLCV6.BVLC_HEADER_LENGTH - 3)
                 {
-                    Log.Warn("Some garbage data got in");
+                    Log.LogWarning("Some garbage data got in");
                 }
                 else
                 {
@@ -247,14 +247,14 @@ public class BacnetIpV6UdpProtocolTransport : BacnetTransportBase
                         case 0:
                             return;
                         case -1:
-                            Log.Debug("Unknow BVLC Header");
+                            Log.LogDebug("Unknow BVLC Header");
                             return;
                     }
 
                     // response to BVLC_REGISTER_FOREIGN_DEVICE (could be BVLC_DISTRIBUTE_BROADCAST_TO_NETWORK ... but we are not a BBMD, don't care)
                     if (function == BacnetBvlcV6Functions.BVLC_RESULT)
                     {
-                        Log.Debug("Receive Register as Foreign Device Response");
+                        Log.LogDebug("Receive Register as Foreign Device Response");
                     }
 
                     // a BVLC_FORWARDED_NPDU frame by a BBMD, change the remote_address to the original one (stored in the BVLC header) 
@@ -275,7 +275,7 @@ public class BacnetIpV6UdpProtocolTransport : BacnetTransportBase
             }
             catch (Exception ex)
             {
-                Log.Error("Exception in udp recieve", ex);
+                Log.LogError(ex, "Exception in udp recieve");
             }
             finally
             {
@@ -288,7 +288,7 @@ public class BacnetIpV6UdpProtocolTransport : BacnetTransportBase
             //restart data receive
             if (conn.Client != null)
             {
-                Log.Error("Exception in Ip OnRecieveData", ex);
+                Log.LogError(ex, "Exception in Ip OnRecieveData");
                 conn.BeginReceive(OnReceiveData, conn);
             }
         }

--- a/Transport/BacnetMstpProtocolTransport.cs
+++ b/Transport/BacnetMstpProtocolTransport.cs
@@ -213,7 +213,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
             _port.Write(frame.Data, 0, tx);
         }
         frame.SendMutex.Set();
-        Log.Debug($"{frame.FrameType} {frame.DestinationAddress:X2}");
+        Log.LogDebug($"{frame.FrameType} {frame.DestinationAddress:X2}");
     }
 
     private void RemoveCurrentMessage(int msgLength)
@@ -351,7 +351,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
                         }
                         catch (Exception ex)
                         {
-                            Log.Error("Exception in MessageRecieved event", ex);
+                            Log.LogError(ex, "Exception in MessageRecieved event");
                         }
                     }
 
@@ -483,7 +483,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
                                 }
                                 catch (Exception ex)
                                 {
-                                    Log.Error("Exception in MessageRecieved event", ex);
+                                    Log.LogError(ex, "Exception in MessageRecieved event");
                                 }
                                 if (frameType == BacnetMstpFrameTypes.FRAME_TYPE_BACNET_DATA_EXPECTING_REPLY)
                                 {
@@ -511,15 +511,15 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
             }
             else if (status == GetMessageStatus.ConnectionClose)
             {
-                Log.Debug("No connection");
+                Log.LogDebug("No connection");
             }
             else if (status == GetMessageStatus.ConnectionError)
             {
-                Log.Debug("Connection Error");
+                Log.LogDebug("Connection Error");
             }
             else
             {
-                Log.Debug("Garbage");
+                Log.LogDebug("Garbage");
             }
         }
 
@@ -557,7 +557,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
 
             while (_port != null)
             {
-                Log.Debug(stateChange);
+                Log.LogDebug("{StateChange}", stateChange);
 
                 switch (stateChange)
                 {
@@ -606,11 +606,11 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
                         break;
                 }
             }
-            Log.Debug("MSTP thread is closing down");
+            Log.LogDebug("MSTP thread is closing down");
         }
         catch (Exception ex)
         {
-            Log.Error("Exception in MSTP thread", ex);
+            Log.LogError(ex, "Exception in MSTP thread");
         }
 
         IsRunning = false;
@@ -630,7 +630,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
             //move back
             Array.Copy(_localBuffer, i, _localBuffer, 0, _localOffset - i);
             _localOffset -= i;
-            Log.Debug("Garbage");
+            Log.LogDebug("Garbage");
             return;
         }
 
@@ -641,7 +641,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
             {
                 _localBuffer[0] = MSTP.MSTP_PREAMBLE1;
                 _localOffset = 1;
-                Log.Debug("Garbage");
+                Log.LogDebug("Garbage");
             }
             return;
         }
@@ -650,7 +650,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
         if (_localOffset > 0)
         {
             _localOffset = 0;
-            Log.Debug("Garbage");
+            Log.LogDebug("Garbage");
         }
     }
 
@@ -780,7 +780,7 @@ public class BacnetMstpProtocolTransport : BacnetTransportBase
                 o => { FrameRecieved(this, frameTypeCopy, destinationAddressCopy, sourceAddressCopy, msgLengthCopy); }, null);
         }
 
-        Log.Debug($"{frameType} {destinationAddress:X2}");
+        Log.LogDebug($"{frameType} {destinationAddress:X2}");
 
         //done
         return GetMessageStatus.Good;

--- a/Transport/BacnetPipeTransport.cs
+++ b/Transport/BacnetPipeTransport.cs
@@ -23,8 +23,8 @@ public class BacnetPipeTransport : IBacnetSerialTransport
             }
             catch (Exception ex)
             {
-                var log = LogManager.GetLogger<BacnetPipeTransport>();
-                log.Warn("Exception in AvailablePorts", ex);
+                var log = BacnetLogging.CreateLogger<BacnetPipeTransport>();
+                log.LogWarning(ex, "Exception in AvailablePorts");
                 return InteropAvailablePorts;
             }
         }

--- a/Transport/BacnetPtpProtocolTransport.cs
+++ b/Transport/BacnetPtpProtocolTransport.cs
@@ -42,7 +42,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
         if (!_maySend.WaitOne(timeout))
             return -BacnetMstpProtocolTransport.ETIMEDOUT;
 
-        Log.Debug(frameType);
+        Log.LogDebug("{FrameType}", frameType);
 
         //send
         SendWithXonXoff(buffer, offset - HeaderLength, fullLength);
@@ -91,7 +91,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
 
     private void SendGreeting()
     {
-        Log.Debug("Sending Greeting");
+        Log.LogDebug("Sending Greeting");
         byte[] greeting = { PTP.PTP_GREETING_PREAMBLE1, PTP.PTP_GREETING_PREAMBLE2, 0x43, 0x6E, 0x65, 0x74, 0x0D }; // BACnet\n
         _port.Write(greeting, 0, greeting.Length);
     }
@@ -182,11 +182,11 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
             ////wait for greeting
             //if (!WaitForGreeting(-1))
             //{
-            //    Log.Debug("Garbage Greeting");
+            //    Log.LogDebug("Garbage Greeting");
             //    return false;
             //}
             //if (StateLogging)
-            //    Log.Debug("Got Greeting");
+            //    Log.LogDebug("Got Greeting");
 
             ////request connection
             //SendFrame(BacnetPtpFrameTypes.FRAME_TYPE_CONNECT_REQUEST);
@@ -215,7 +215,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
             //move back
             Array.Copy(buffer, i, buffer, 0, length - i);
             length -= i;
-            Log.Debug("Garbage");
+            Log.LogDebug("Garbage");
             return;
         }
 
@@ -225,7 +225,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
         {
             buffer[0] = buffer[length - 1];
             length = 1;
-            Log.Debug("Garbage");
+            Log.LogDebug("Garbage");
             return;
         }
 
@@ -234,7 +234,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
             return;
 
         length = 0;
-        Log.Debug("Garbage");
+        Log.LogDebug("Garbage");
     }
 
     private static void RemoveXonOff(byte[] buffer, int offset, ref int maxOffset, ref bool complimentNext)
@@ -291,7 +291,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
         if (buffer == null) buffer = new byte[fullLength];
         PTP.Encode(buffer, 0, frameType, msgLength);
 
-        Log.Debug(frameType);
+        Log.LogDebug("{FrameType}", frameType);
 
         //send
         SendWithXonXoff(buffer, 0, fullLength);
@@ -375,7 +375,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
             if (IsGreeting(buffer, 0, offset))
             {
                 frameType = BacnetPtpFrameTypes.FRAME_TYPE_GREETING;
-                Log.Debug(frameType);
+                Log.LogDebug("{FrameType}", frameType);
                 return BacnetMstpProtocolTransport.GetMessageStatus.Good;
             }
             //drop message
@@ -430,7 +430,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
             }
         }
 
-        Log.Debug(frameType);
+        Log.LogDebug("{FrameType}", frameType);
 
         //done
         return BacnetMstpProtocolTransport.GetMessageStatus.Good;
@@ -462,16 +462,16 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
                 {
                     case BacnetMstpProtocolTransport.GetMessageStatus.ConnectionClose:
                     case BacnetMstpProtocolTransport.GetMessageStatus.ConnectionError:
-                        Log.Warn("Connection disturbance");
+                        Log.LogWarning("Connection disturbance");
                         Reconnect();
                         break;
 
                     case BacnetMstpProtocolTransport.GetMessageStatus.DecodeError:
-                        Log.Warn("PTP decode error");
+                        Log.LogWarning("PTP decode error");
                         break;
 
                     case BacnetMstpProtocolTransport.GetMessageStatus.SubTimeout:
-                        Log.Warn("PTP frame abort");
+                        Log.LogWarning("PTP frame abort");
                         break;
 
                     case BacnetMstpProtocolTransport.GetMessageStatus.Timeout:
@@ -574,7 +574,7 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
                                 if (msgLength > 0)
                                     reason = (BacnetPtpDisconnectReasons)buffer[PTP.PTP_HEADER_LENGTH];
                                 SendFrame(BacnetPtpFrameTypes.FRAME_TYPE_DISCONNECT_RESPONSE);
-                                Log.Debug($"Disconnect requested: {reason}");
+                                Log.LogDebug($"Disconnect requested: {reason}");
                                 Reconnect();
                                 break;
 
@@ -594,11 +594,11 @@ public class BacnetPtpProtocolTransport : BacnetTransportBase
                         break;
                 }
             }
-            Log.Debug("PTP thread is closing down");
+            Log.LogDebug("PTP thread is closing down");
         }
         catch (Exception ex)
         {
-            Log.Error($"Exception in PTP thread", ex);
+            Log.LogError(ex, $"Exception in PTP thread");
         }
     }
 }

--- a/Transport/BacnetTransportBase.cs
+++ b/Transport/BacnetTransportBase.cs
@@ -2,7 +2,7 @@
 
 public abstract class BacnetTransportBase : IBacnetTransport
 {
-    public ILog Log { get; set; }
+    public ILogger Log { get; set; }
     public int HeaderLength { get; protected set; }
     public int MaxBufferLength { get; protected set; }
     public BacnetAddressTypes Type { get; protected set; }
@@ -11,7 +11,7 @@ public abstract class BacnetTransportBase : IBacnetTransport
 
     protected BacnetTransportBase()
     {
-        Log = LogManager.GetLogger(GetType());
+        Log = BacnetLogging.CreateLogger(GetType());
     }
 
     public abstract void Start();


### PR DESCRIPTION
Phase 7 of the 4.0 modernization — swap the unmaintained `Common.Logging` for the standard **`Microsoft.Extensions.Logging`** abstractions (addresses #146 / #36). **Breaking** (public `Log` property type changes).

## What
- The `Log` property on `BacnetClient`, `BVLC`, `BVLCV6` and every transport changes type: `Common.Logging.ILog` → `Microsoft.Extensions.Logging.ILogger`. Default is a no-op `NullLogger`.
- New **`BacnetLogging.Factory`** (an `ILoggerFactory`) is the *configure-once* injection path — set it at start-up and every stack object created afterwards logs through it. Per-instance override via `instance.Log = factory.CreateLogger<T>()` still works.
- All **148 call-sites** migrated to MEL (`Debug→LogDebug`, `Warn→LogWarning`, …). The exception moves to the first argument on the 18 `Log.Error(msg, ex)` sites; the lone `Log.WarnFormat("…", e)` is **fixed** along the way (Common.Logging silently dropped the exception with no `{0}` placeholder). 5 enum-valued `Debug(enum)` calls became structured `LogDebug("{X}", enum)`.
- **`Microsoft.CSharp`** is now referenced explicitly on netstandard2.0 — it used to arrive transitively via Common.Logging and is required for the `dynamic` runtime binder.
- Package `Common.Logging 3.4.1` → `Microsoft.Extensions.Logging.Abstractions 8.0.2` (single version; the ns2.0 asset serves all four TFMs). Providers are the consumer's choice.

## Migration
See the new **`MIGRATION.md`** — console / Serilog / NLog / **log4net** (via `AddLog4Net`) wiring, plus the transport-split guide. An optional `BACnet.Logging.CommonLogging` bridge package (for consumers keeping their Common.Logging sinks) will follow as a separate PR.

## Verified locally
Core graph is now MEL.Abstractions (+ Microsoft.CSharp on ns2.0), zero Common.Logging; all four core TFMs + BACnet.Ethernet/Serial/Tests build with **no warnings**; **119 tests pass**.