### PR TITLE
chore: tag-driven versioning with MinVer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # MinVer needs full history + tags to compute the version
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,12 +15,20 @@
     <RepositoryUrl>https://github.com/ela-compil/BACnet</RepositoryUrl>
 
     <!-- Packing is a release-time concern handled by the CI pack/publish workflow (Phase 9),
-         not every local build. MinVer-based versioning is wired in Phase 8. -->
+         not every local build. -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 
-    <!-- Pin AssemblyVersion to major-only so net48 consumers avoid binding-redirect churn on every
-         release; the package/file versions float (MinVer, Phase 8). -->
+    <!-- Versioning is tag-driven via MinVer: the git tag IS the package/file version. Release tags
+         are v-prefixed (e.g. v4.0.0); MinimumMajorMinor floors untagged builds at 4.0.0-alpha.0.<height>
+         until the first v4 tag. AssemblyVersion stays pinned major-only so net48 consumers avoid
+         binding-redirect churn on every release. -->
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <MinVerTagPrefix>v</MinVerTagPrefix>
+    <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MinVer" PrivateAssets="all" />
+  </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,11 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
+  <!-- Build tooling -->
+  <ItemGroup>
+    <PackageVersion Include="MinVer" Version="6.0.0" />
+  </ItemGroup>
+
   <!-- Core dependencies -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />


### PR DESCRIPTION
Phase 8 of the 4.0 modernization — the git tag becomes the version.

- Add **MinVer** (`PrivateAssets=all`, via CPM) in `Directory.Build.props` with `MinVerTagPrefix=v` and `MinVerMinimumMajorMinor=4.0`. A `v4.0.0` tag yields `4.0.0`; untagged commits become `4.0.0-alpha.0.<height>` (verified: the built assembly reports `4.0.0-alpha.0.299+<sha>`).
- `AssemblyVersion` stays pinned `4.0.0.0` (major-only, no net48 binding-redirect churn); package/file versions float from the tag.
- `build.yml`: `fetch-depth: 0` on checkout so MinVer can see full history + tags.

Note: existing tags are bare (`3.0.2`), so the `v` prefix cleanly separates the 4.x release line; `release.yml` (tag-triggered pack/publish) lands in Phase 9.

## Verified locally
All projects build; **119 tests pass**.