### PR TITLE
ci: ignore major bumps for runtime dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    ignore:
+      # Keep the library's runtime dependency floors low: a library forcing a new major of these
+      # ubiquitous packages would push that major onto every consumer's graph. Take majors here
+      # deliberately, not automatically (minor/patch updates are still proposed).
+      - dependency-name: "Microsoft.Extensions.Logging"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "Microsoft.Extensions.Logging.Abstractions"
+        update-types: ["version-update:semver-major"]
+      # System.IO.Ports is pinned per-TFM to match the runtime major (net8 -> 8.x, net10 -> 10.x);
+      # a cross-major bump on the net8 pin would force .NET 8 consumers onto System.IO.Ports 10.x.
+      - dependency-name: "System.IO.Ports"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions used by the build/release workflows.
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Adds Dependabot `ignore` rules so major bumps of the library's **runtime** dependencies aren't auto-proposed (they raise the floor for every consumer). Minor/patch updates are still offered; majors are taken deliberately.

- `Microsoft.Extensions.Logging` — major ignored (keep the bridge's floor low)
- `Microsoft.Extensions.Logging.Abstractions` — major ignored (keep the core's floor low)
- `System.IO.Ports` — major ignored (it's pinned per-TFM to match the runtime major; a cross-major bump on the net8 pin would force .NET 8 consumers onto 10.x)

This is why #183, #184 (Extensions) and #188 (System.IO.Ports) were closed. **MinVer is intentionally left out** — it's build-time only and its major bump (#187) should be reviewed and taken after 4.0 ships, not suppressed.