### PR TITLE
docs: packages as a list + prerelease NuGet badges

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,7 +92,7 @@ The `(portName, baudRate, …)` convenience constructors on `BacnetMstpProtocolT
 The core still contains the MS/TP and PTP protocol logic and the `IBacnetSerialTransport` abstraction;
 only the physical `SerialPort` implementation moved.
 
-## Network interface must be explicit on multi-homed hosts
+## Network interface must be explicit when a host has multiple interfaces
 
 In 3.x, `BacnetIpUdpProtocolTransport` silently picked a network interface for you when the machine
 had more than one. That guess was frequently wrong — binding the BACnet/IP broadcast to a virtual

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -91,3 +91,20 @@ The `(portName, baudRate, …)` convenience constructors on `BacnetMstpProtocolT
 
 The core still contains the MS/TP and PTP protocol logic and the `IBacnetSerialTransport` abstraction;
 only the physical `SerialPort` implementation moved.
+
+## Network interface must be explicit on multi-homed hosts
+
+In 3.x, `BacnetIpUdpProtocolTransport` silently picked a network interface for you when the machine
+had more than one. That guess was frequently wrong — binding the BACnet/IP broadcast to a virtual
+adapter (Hyper-V, WSL, Docker, a VPN) instead of the real LAN — and the failure was easy to miss.
+
+4.0 stops guessing. When several candidate IPv4 interfaces are present and you have not said which to
+use, `Start()` now throws an `InvalidOperationException` listing the candidates rather than binding to
+the wrong one. Hosts with a single interface are unaffected.
+
+Select the interface by passing its local IP to the constructor:
+
+```diff
+- var transport = new BacnetIpUdpProtocolTransport(0xBAC0);
++ var transport = new BacnetIpUdpProtocolTransport(0xBAC0, localEndpointIp: "192.168.1.50");
+```

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ dotnet add package BACnet.Serial
 
 ## Getting started
 
-A minimal Who-Is / read a property over BACnet/IP:
+A minimal Who-Is device discovery over BACnet/IP:
 
 ```csharp
 using System.IO.BACnet;
@@ -59,6 +59,10 @@ client.OnIam += (sender, adr, deviceId, maxApdu, seg, vendorId)
 client.Start();
 client.WhoIs();
 ```
+
+> On a host with several network interfaces (e.g. Hyper-V/WSL/Docker virtual adapters), tell the
+> transport which one to bind by passing its IP — otherwise it throws an error listing the candidates:
+> `new BacnetIpUdpProtocolTransport(0xBAC0, localEndpointIp: "192.168.1.50")`.
 
 The [`Examples/`](https://github.com/ela-compil/BACnet/tree/master/Examples) folder has runnable samples — basic read/write, a device/server,
 COV subscription, alarm/event handling, BBMD, a serial device, and more.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Console, Serilog, NLog, and log4net all work via their MEL providers. If you alr
 - **Logging** moved from `Common.Logging` to `Microsoft.Extensions.Logging` (the `Log` property is now `ILogger`).
 - **Native transports** split into optional packages: pcap → `BACnet.Ethernet`, serial → `BACnet.Serial`.
   The MS/TP and PTP protocols stay in the core; use `SerialTransport.Mstp(...)` / `.Ptp(...)` from `BACnet.Serial`.
+- **Interface selection is explicit on multi-homed hosts.** When more than one network interface is
+  present, `BacnetIpUdpProtocolTransport` no longer picks one for you — `Start()` throws and lists the
+  candidates. Pass the interface IP: `new BacnetIpUdpProtocolTransport(0xBAC0, localEndpointIp: "192.168.1.50")`.
 
 ## GitHub Packages
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ Console, Serilog, NLog, and log4net all work via their MEL providers. If you alr
 - **Logging** moved from `Common.Logging` to `Microsoft.Extensions.Logging` (the `Log` property is now `ILogger`).
 - **Native transports** split into optional packages: pcap → `BACnet.Ethernet`, serial → `BACnet.Serial`.
   The MS/TP and PTP protocols stay in the core; use `SerialTransport.Mstp(...)` / `.Ptp(...)` from `BACnet.Serial`.
-- **Interface selection is explicit on multi-homed hosts.** When more than one network interface is
-  present, `BacnetIpUdpProtocolTransport` no longer picks one for you — `Start()` throws and lists the
+- **Interface selection is explicit when the host has multiple network interfaces.** In that case
+  `BacnetIpUdpProtocolTransport` no longer picks one for you — `Start()` throws and lists the
   candidates. Pass the interface IP: `new BacnetIpUdpProtocolTransport(0xBAC0, localEndpointIp: "192.168.1.50")`.
 
 ## GitHub Packages

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://raw.githubusercontent.com/ela-compil/BACnet/master/logo.png" alt="BACnet logo" align="right" width="130" />
+
 # .NET library for BACnet
 
 [![build](https://github.com/ela-compil/BACnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/ela-compil/BACnet/actions/workflows/build.yml)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![build](https://github.com/ela-compil/BACnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/ela-compil/BACnet/actions/workflows/build.yml)
 [![NuGet](https://img.shields.io/nuget/vpre/BACnet.svg?label=BACnet)](https://www.nuget.org/packages/BACnet)
+[![Downloads](https://img.shields.io/nuget/dt/BACnet.svg?label=downloads)](https://www.nuget.org/packages/BACnet)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ela-compil/BACnet/blob/master/LICENSE)
 
 A standalone BACnet protocol stack for .NET.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ A standalone BACnet protocol stack for .NET.
 The stack was originally developed by **Morten Kvistgaard** — with significant contributions from
 **F. Chaxel**, **Steve Karg**, and the [BACnet Stack (in C)](https://sourceforge.net/projects/bacnet/) —
 as part of [YABE (Yet Another BACnet Explorer)](https://sourceforge.net/projects/yetanotherbacnetexplorer/).
-This repository was **forked from the YABE SourceForge SVN** and is maintained here as an independent
-library on NuGet; it is a separate codebase from YABE (YABE keeps its own copy of the stack).
+This repository was **forked from the YABE SourceForge SVN** and is maintained here by
+**Jakub Bartkowiak** and the **Ela-compil** team as an independent library on NuGet; it is a separate
+codebase from YABE (YABE keeps its own copy of the stack).
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # .NET library for BACnet
 
 [![build](https://github.com/ela-compil/BACnet/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/ela-compil/BACnet/actions/workflows/build.yml)
-[![NuGet](https://img.shields.io/nuget/v/BACnet.svg?label=BACnet)](https://www.nuget.org/packages/BACnet)
+[![NuGet](https://img.shields.io/nuget/vpre/BACnet.svg?label=BACnet)](https://www.nuget.org/packages/BACnet)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ela-compil/BACnet/blob/master/LICENSE)
 
 A standalone BACnet protocol stack for .NET.
@@ -14,12 +14,14 @@ library on NuGet; it is a separate codebase from YABE (YABE keeps its own copy o
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| [![NuGet](https://img.shields.io/nuget/v/BACnet.svg?label=BACnet)](https://www.nuget.org/packages/BACnet) | Core stack — pure-managed BACnet/IP, MS/TP & PTP protocol, encode/decode. No native dependencies. |
-| [![NuGet](https://img.shields.io/nuget/v/BACnet.Ethernet.svg?label=BACnet.Ethernet)](https://www.nuget.org/packages/BACnet.Ethernet) | pcap-based BACnet/Ethernet (ISO 8802-3) transport (SharpPcap / PacketDotNet). |
-| [![NuGet](https://img.shields.io/nuget/v/BACnet.Serial.svg?label=BACnet.Serial)](https://www.nuget.org/packages/BACnet.Serial) | Physical serial-port transport (`System.IO.Ports`) for MS/TP and PTP. |
-| [![NuGet](https://img.shields.io/nuget/v/BACnet.Logging.CommonLogging.svg?label=BACnet.Logging.CommonLogging)](https://www.nuget.org/packages/BACnet.Logging.CommonLogging) | Optional bridge to route the stack's logs to `Common.Logging`. |
+- **[BACnet](https://www.nuget.org/packages/BACnet)** [![NuGet](https://img.shields.io/nuget/vpre/BACnet.svg?label=nuget)](https://www.nuget.org/packages/BACnet)  
+  Core stack — pure-managed BACnet/IP, MS/TP & PTP protocol, encode/decode. No native dependencies.
+- **[BACnet.Ethernet](https://www.nuget.org/packages/BACnet.Ethernet)** [![NuGet](https://img.shields.io/nuget/vpre/BACnet.Ethernet.svg?label=nuget)](https://www.nuget.org/packages/BACnet.Ethernet)  
+  pcap-based BACnet/Ethernet (ISO 8802-3) transport (SharpPcap / PacketDotNet).
+- **[BACnet.Serial](https://www.nuget.org/packages/BACnet.Serial)** [![NuGet](https://img.shields.io/nuget/vpre/BACnet.Serial.svg?label=nuget)](https://www.nuget.org/packages/BACnet.Serial)  
+  Physical serial-port transport (`System.IO.Ports`) for MS/TP and PTP.
+- **[BACnet.Logging.CommonLogging](https://www.nuget.org/packages/BACnet.Logging.CommonLogging)** [![NuGet](https://img.shields.io/nuget/vpre/BACnet.Logging.CommonLogging.svg?label=nuget)](https://www.nuget.org/packages/BACnet.Logging.CommonLogging)  
+  Optional bridge to route the stack's logs to `Common.Logging`.
 
 ## Supported target frameworks
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,22 @@
 [![Downloads](https://img.shields.io/nuget/dt/BACnet.svg?label=downloads)](https://www.nuget.org/packages/BACnet)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://github.com/ela-compil/BACnet/blob/master/LICENSE)
 
-A standalone BACnet protocol stack for .NET.
+[BACnet](http://www.bacnet.org/) (ASHRAE 135) is the standard communication protocol for
+building-automation systems — HVAC, lighting, access control, and metering. This library is a
+standalone BACnet stack for .NET: add a NuGet package and talk to BACnet devices from your own code,
+or expose your application as a BACnet device.
 
-The stack was originally developed by **Morten Kvistgaard** — with significant contributions from
-**F. Chaxel**, **Steve Karg**, and the [BACnet Stack (in C)](https://sourceforge.net/projects/bacnet/) —
-as part of [YABE (Yet Another BACnet Explorer)](https://sourceforge.net/projects/yetanotherbacnetexplorer/).
-This repository was **forked from the YABE SourceForge SVN** and is maintained here by
-**Jakub Bartkowiak** and the **Ela-compil** team as an independent library on NuGet; it is a separate
-codebase from YABE (YABE keeps its own copy of the stack).
+## Features
+
+- **Transports** — BACnet/IP (UDP, IPv4 & IPv6) with BBMD and foreign-device registration; BACnet/Ethernet (pcap); MS/TP and PTP over a serial port
+- **Client and device (server) roles** — send requests and/or answer them from your own object model
+- **Discovery** — Who-Is / I-Am and Who-Has / I-Have, including across routers
+- **Data access** — ReadProperty, WriteProperty, ReadPropertyMultiple, WritePropertyMultiple, ReadRange
+- **Change of Value** — SubscribeCOV / SubscribeProperty and COV notifications
+- **Alarms & events** — event/alarm notifications, alarm summary, and acknowledgement
+- **More services** — object create/delete, atomic file read/write, device-communication-control, reinitialize, time synchronization
+- **Segmentation** of large requests and responses
+- Complete **ASN.1 encode/decode** of the BACnet APDU set, covered by a test suite verified against ASHRAE 135 Annex F
 
 ## Packages
 
@@ -105,4 +113,17 @@ Releases are also published to GitHub Packages. To restore from there, add the s
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](https://github.com/ela-compil/BACnet/blob/master/CONTRIBUTING.md). Licensed under the [MIT License](https://github.com/ela-compil/BACnet/blob/master/LICENSE).
+See [`CONTRIBUTING.md`](https://github.com/ela-compil/BACnet/blob/master/CONTRIBUTING.md).
+
+## Credits & history
+
+The stack was originally developed by **Morten Kvistgaard** — with significant contributions from
+**F. Chaxel**, **Steve Karg**, and the [BACnet Stack (in C)](https://sourceforge.net/projects/bacnet/) —
+as part of [YABE (Yet Another BACnet Explorer)](https://sourceforge.net/projects/yetanotherbacnetexplorer/).
+This repository was **forked from the YABE SourceForge SVN** and is maintained here by
+[**Jakub Bartkowiak**](https://github.com/gralin) and the [**Ela-compil**](https://ela.pl) team as an
+independent library on NuGet; it is a separate codebase from YABE (YABE keeps its own copy of the stack).
+
+## License
+
+[MIT](https://github.com/ela-compil/BACnet/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -54,10 +54,15 @@ A minimal Who-Is device discovery over BACnet/IP:
 using System.IO.BACnet;
 
 var client = new BacnetClient(new BacnetIpUdpProtocolTransport(0xBAC0));
+
 client.OnIam += (sender, adr, deviceId, maxApdu, seg, vendorId)
     => Console.WriteLine($"Found device {deviceId} at {adr}");
+
 client.Start();
+
 client.WhoIs();
+
+Console.ReadLine();
 ```
 
 > On a host with several network interfaces (e.g. Hyper-V/WSL/Docker virtual adapters), tell the

--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ independent library on NuGet; it is a separate codebase from YABE (YABE keeps it
 ## License
 
 [MIT](https://github.com/ela-compil/BACnet/blob/master/LICENSE).
+
+## Trademarks
+
+"BACnet" and the BACnet logo are registered trademarks of [ASHRAE](https://www.ashrae.org/) (the
+American Society of Heating, Refrigerating and Air-Conditioning Engineers, Inc.). This project is an
+independent, community-maintained implementation of the BACnet protocol; it is not affiliated with,
+endorsed by, or sponsored by ASHRAE or BACnet International. The name and logo are used only to
+identify the protocol this library implements.


### PR DESCRIPTION
- **Packages section** is now a list instead of a two-column table — GitHub can't widen the narrow badge column, and the list reads well on both GitHub and nuget.org.
- **NuGet badges** switched from `nuget/v` (stable only) to `nuget/vpre`, so they show the latest version **including prereleases** — `4.0.0-beta.1` now, and the highest version once `4.0.0` ships.