### PR TITLE
ci: create a GitHub Release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     tags: [ 'v*' ]
 
 permissions:
-  contents: read
+  contents: write   # create the GitHub Release for the pushed tag
   id-token: write   # nuget.org Trusted Publishing (OIDC) — no stored API key
   packages: write   # GitHub Packages — uses the automatic GITHUB_TOKEN
 
@@ -61,3 +61,16 @@ jobs:
           Get-ChildItem artifacts/*.nupkg | ForEach-Object {
             dotnet nuget push $_.FullName --source https://nuget.pkg.github.com/ela-compil/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols
           }
+
+      # 3) GitHub Release — publish a release for the tag with auto-generated notes and the packages
+      #    attached. Tags with a pre-release suffix (e.g. -beta.1 / -rc.1) are flagged as prereleases
+      #    so they are not shown as the "Latest" release.
+      - name: Create GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = '${{ github.ref_name }}'
+          $assets = (Get-ChildItem artifacts/*.nupkg).FullName
+          $flags = if ($tag -match '-') { @('--prerelease') } else { @() }
+          gh release create $tag @assets --title $tag --generate-notes @flags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,15 @@ jobs:
             dotnet nuget push $_.FullName --source https://nuget.pkg.github.com/ela-compil/index.json --api-key ${{ secrets.GITHUB_TOKEN }} --skip-duplicate --no-symbols
           }
 
-      # 3) GitHub Release — publish a release for the tag with auto-generated notes and the packages
-      #    attached. Tags with a pre-release suffix (e.g. -beta.1 / -rc.1) are flagged as prereleases
-      #    so they are not shown as the "Latest" release.
+      # 3) GitHub Release — publish a release for the tag with auto-generated notes (GitHub attaches
+      #    the source archives automatically; the packages live on nuget.org / GitHub Packages). Tags
+      #    with a pre-release suffix (e.g. -beta.1 / -rc.1) are flagged as prereleases so they are not
+      #    shown as the "Latest" release.
       - name: Create GitHub Release
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           $tag = '${{ github.ref_name }}'
-          $assets = (Get-ChildItem artifacts/*.nupkg).FullName
           $flags = if ($tag -match '-') { @('--prerelease') } else { @() }
-          gh release create $tag @assets --title $tag --generate-notes @flags
+          gh release create $tag --title $tag --generate-notes @flags


### PR DESCRIPTION
The release workflow pushed packages to nuget.org + GitHub Packages but never created a **GitHub Release** (the tagged entry on the Releases page). Add a final step:

```
gh release create <tag> --title <tag> --generate-notes [--prerelease]
```

- Auto-generates release notes from the commits/PRs since the previous release.
- Uses GitHub's automatic **source archives** as the release assets (the packages themselves live on nuget.org / GitHub Packages — no need to duplicate them).
- Flags the release as a **prerelease** when the tag has a `-beta`/`-rc` suffix, so stable `v4.0.0` becomes 'Latest' but `v4.0.0-beta.1` does not.
- Needs `contents: write` (added).

Applies to future tags.