### PR TITLE
fix: intrinsic alarm crash in the storage example (the "Hmm?" exception)

### DIFF
--- a/Examples/AnotherStorageImplementation/BacnetObjects/AnalogObjectEvent.cs
+++ b/Examples/AnotherStorageImplementation/BacnetObjects/AnalogObjectEvent.cs
@@ -253,13 +253,24 @@ namespace BaCSharp
             // look for the related notification class object
             NotificationClass nc=(NotificationClass)Mydevice.FindBacnetObject(new BacnetObjectId(BacnetObjectTypes.OBJECT_NOTIFICATION_CLASS,m_PROP_NOTIFICATION_CLASS));
   
-            if (nc!=null)
+            if (nc != null)
+            {
+                // An analog high/low-limit alarm is an Out_Of_Range event; report the present value
+                // and the limit that was crossed.
+                bool high = toState == (int)BacnetEventStates.EVENT_STATE_HIGH_LIMIT
+                         || fromState == (uint)BacnetEventStates.EVENT_STATE_HIGH_LIMIT;
+
                 nc.SendIntrinsectEvent(
                     m_PROP_OBJECT_IDENTIFIER,
                     (BacnetNotifyTypes)m_PROP_NOTIFY_TYPE,
-                    BacnetEventTypes.EVENT_CHANGE_OF_VALUE,
+                    BacnetEventTypes.EVENT_OUT_OF_RANGE,
                     (BacnetEventStates)fromState,
-                    (BacnetEventStates)toState);
+                    (BacnetEventStates)toState,
+                    Convert.ToSingle(m_PROP_PRESENT_VALUE),
+                    m_PROP_STATUS_FLAGS,
+                    Convert.ToSingle(m_PROP_DEADBAND),
+                    Convert.ToSingle(high ? m_PROP_HIGH_LIMIT : m_PROP_LOW_LIMIT));
+            }
         }
     }
 }

--- a/Examples/AnotherStorageImplementation/BacnetObjects/NotificationClass.cs
+++ b/Examples/AnotherStorageImplementation/BacnetObjects/NotificationClass.cs
@@ -120,7 +120,9 @@ namespace BaCSharp
                     BacnetNotifyTypes notifyType,
                     BacnetEventTypes evenType,
                     BacnetEventStates fromstate,
-                    BacnetEventStates tostate)
+                    BacnetEventStates tostate,
+                    float exceedingValue = 0, BacnetBitString statusFlags = default,
+                    float deadband = 0, float exceededLimit = 0)
         {
 
             if ((m_PROP_RECIPIENT_LIST == null) || (m_PROP_RECIPIENT_LIST.Count == 0))
@@ -136,6 +138,16 @@ namespace BaCSharp
             bacnetEvent.fromState = fromstate;
             bacnetEvent.notifyType = notifyType;
             bacnetEvent.eventType = evenType;
+
+            // Event-specific payload. This sample raises analog limit alarms (Out_Of_Range);
+            // the encoder needs these fields filled for that event type.
+            if (evenType == BacnetEventTypes.EVENT_OUT_OF_RANGE)
+            {
+                bacnetEvent.outOfRange_exceedingValue = exceedingValue;
+                bacnetEvent.outOfRange_statusFlags = statusFlags;
+                bacnetEvent.outOfRange_deadband = deadband;
+                bacnetEvent.outOfRange_exceededLimit = exceededLimit;
+            }
 
             BacnetGenericTime timeStamp = new BacnetGenericTime();
             timeStamp.Tag = BacnetTimestampTags.TIME_STAMP_DATETIME;
@@ -201,8 +213,17 @@ namespace BaCSharp
                     {
                         lock (bacnetEventlock)
                         {
-                            bacnetEvent.processIdentifier = processIdentifier;
-                            recipient.Value.Key.SendUnconfirmedEventNotification(recipient.Value.Value, bacnetEvent);
+                            try
+                            {
+                                bacnetEvent.processIdentifier = processIdentifier;
+                                recipient.Value.Key.SendUnconfirmedEventNotification(recipient.Value.Value, bacnetEvent);
+                            }
+                            catch (Exception ex)
+                            {
+                                // This runs on a thread-pool thread: an unhandled exception would take
+                                // down the whole device, so log and carry on.
+                                System.Diagnostics.Trace.TraceError("Failed to send event notification: " + ex.Message);
+                            }
                         }
 
                     }, null);

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -1221,7 +1221,7 @@ public class Services
                                 break;
 
                             default:
-                                throw new Exception("Hmm?");
+                                throw new NotImplementedException($"changeOfValue_tag {data.changeOfValue_tag} is not supported for EVENT_CHANGE_OF_VALUE");
                         }
 
                         ASN1.encode_closing_tag(buffer, 0);


### PR DESCRIPTION
Discovered while running `AnotherStorageImplementation` and clicking the device in YABE: as soon as an object's intrinsic limit alarm fired, the device crashed with:

```
System.Exception: Hmm?
  at System.IO.BACnet.Serialize.Services.EncodeEventNotifyData(...) Services.cs:1224
  ...
  at BaCSharp.NotificationClass...SendIntrinsectEvent...
```

## Root causes
1. **Core** — `EncodeEventNotifyData` had a leftover placeholder `throw new Exception("Hmm?")` in the `EVENT_CHANGE_OF_VALUE` default branch. Replaced with a meaningful `NotImplementedException` (matching the sibling switch one level up).
2. **Example** — `AnalogObjectEvent` reported analog high/low-limit alarms as `EVENT_CHANGE_OF_VALUE` with no payload, which the encoder can't serialize. It now sends **`EVENT_OUT_OF_RANGE`** with the proper payload (exceeding value, status flags, deadband, exceeded limit) — the correct BACnet event for an analog limit alarm.
3. **Example robustness** — the notification is sent on a thread-pool thread; an unhandled exception there took down the whole device process. Wrapped it in try/catch so a failed send is logged instead.

## Verified
- Core + example build; 119 tests pass.
- `EVENT_OUT_OF_RANGE` with payload now encodes cleanly; an unset `CHANGE_OF_VALUE` throws the new meaningful `NotImplementedException` instead of `"Hmm?"`.

Result: clicking the device in YABE now shows a proper Out-Of-Range alarm instead of crashing.