### PR TITLE
new: configurable UDP receive buffer (SO_RCVBUF), default 1 MB

### DIFF
--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -43,6 +43,21 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
     public int SharedPort { get; }
     public int ExclusivePort { get; }
 
+    private int _receiveBufferSize = 1024 * 1024; // 1 MB
+
+    /// <summary>
+    /// UDP receive buffer size (SO_RCVBUF) in bytes, defaulting to 1 MB. A larger buffer lets the OS
+    /// hold a bigger burst of incoming messages before it starts dropping packets. It may be changed
+    /// at any time — including after <see cref="Start"/> — and is applied to the live socket(s)
+    /// immediately. On Linux the effective value is capped by net.core.rmem_max (raise that via
+    /// sysctl to go higher); the getter returns the requested value, not the OS-adjusted one.
+    /// </summary>
+    public int ReceiveBufferSize
+    {
+        get => _receiveBufferSize;
+        set { _receiveBufferSize = value; ApplyReceiveBufferSize(); }
+    }
+
     // Give 0.0.0.0:xxxx if the socket is open with System.Net.IPAddress.Any
     // Today only used by _GetBroadcastAddress method & the bvlc layer class in BBMD mode
     // Some more complex solutions could avoid this, that's why this property is virtual
@@ -138,7 +153,17 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
             Log.LogInformation($"Binded exclusively to {ep} using UDP");
         }
 
+        ApplyReceiveBufferSize();
+
         Bvlc = new BVLC(this);
+    }
+
+    private void ApplyReceiveBufferSize()
+    {
+        // SO_RCVBUF can be set on an already-bound socket. Over-requesting is clamped (Linux) or
+        // honored (Windows), never fatal - but guard anyway for constrained platforms.
+        try { if (_sharedConn != null) _sharedConn.Client.ReceiveBufferSize = _receiveBufferSize; } catch { }
+        try { if (_exclusiveConn != null) _exclusiveConn.Client.ReceiveBufferSize = _receiveBufferSize; } catch { }
     }
 
     /// <summary>


### PR DESCRIPTION
Follow-up to the #132 investigation. The UDP transport never set the socket receive buffer, so it used the OS default (**64 KB on Windows**). Under a burst of incoming messages — e.g. event notifications delivered faster than a slow `OnEventNotify` handler drains them — the buffer overflows and the OS **silently drops** packets. That is the "some notifications are missed" in #132.

## Change
- Default the UDP receive buffer to **1 MB**.
- Expose a **`ReceiveBufferSize`** property that can be changed **at any time, including after `Start()`** — it is applied to the live socket(s) immediately.

## Why 1 MB works on PC *and* Raspberry Pi
Over-requesting `SO_RCVBUF` is never fatal:
- **Windows** honors the full 1 MB (16× the 64 KB default).
- **Linux / Raspberry Pi** silently clamp to `net.core.rmem_max` (~208 KB default) — no error, only the clamped amount is allocated (trivial even on a 512 MB Pi). To go higher you raise `net.core.rmem_max` via sysctl.

## Verified
- Build + 119 tests pass.
- The exact scenario that dropped **982/3000** at 64 KB now delivers **3000/3000, 0 dropped** at 1 MB.
- `ReceiveBufferSize` reads back `1048576` by default and successfully changes to 4 MB **after** `Start()` (applied to the live socket).

Note: this raises the burst threshold; the deeper guidance for #132 (return fast from `OnEventNotify`, offload heavy work) still stands.