### PR TITLE
fix!: correct BacnetRejectReason typo RECOGNIZED_SERVICE -> UNRECOGNIZED_SERVICE

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -440,7 +440,7 @@ public class BacnetClient : IDisposable
                         Log.LogWarning("Couldn't decode GetAlarmSummary");
                     }
 #else
-                SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
+                SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.UNRECOGNIZED_SERVICE);
 #endif
             }
             else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_GET_EVENT_INFORMATION && OnGetAlarmSummaryOrEventInformation != null)
@@ -478,7 +478,7 @@ public class BacnetClient : IDisposable
             else
             {
                 // DAL
-                SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE); // should be unrecognized but this is the way it was spelled..
+                SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.UNRECOGNIZED_SERVICE);
                 Log.LogDebug($"Confirmed service not handled: {service}");
             }
         }

--- a/Base/BacnetRejectReason.cs
+++ b/Base/BacnetRejectReason.cs
@@ -80,5 +80,5 @@ public enum BacnetRejectReason : byte
     /// Generated in response to a confirmed request APDU in which the Service Choice
     /// field specifies an unknown or unsupported service
     /// </summary>
-    RECOGNIZED_SERVICE = 9
+    UNRECOGNIZED_SERVICE = 9
 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Console, Serilog, NLog, and log4net all work via their MEL providers. If you alr
 - **Interface selection is explicit when the host has multiple network interfaces.** In that case
   `BacnetIpUdpProtocolTransport` no longer picks one for you — `Start()` throws and lists the
   candidates. Pass the interface IP: `new BacnetIpUdpProtocolTransport(0xBAC0, localEndpointIp: "192.168.1.50")`.
+- **Renamed** the misspelled enum member `BacnetRejectReason.RECOGNIZED_SERVICE` to `UNRECOGNIZED_SERVICE` (value unchanged).
 
 ## GitHub Packages
 


### PR DESCRIPTION
`BacnetRejectReason` value 9 was spelled `RECOGNIZED_SERVICE` — the "UN" was dropped during the port. Verified in spect:

- **ASHRAE 135** — `BACnetRejectReason ::= ENUMERATED { … unrecognized-service (9) … }`

The enumeration **value (9) is unchanged**, so this is wire-compatible; only the public member name is corrected.

Closes #104.