### PR TITLE
test: routed 6-byte VMAC address round-trip (#27)

### DIFF
--- a/Tests/Serialize/NpduRoutedAddressTests.cs
+++ b/Tests/Serialize/NpduRoutedAddressTests.cs
@@ -1,0 +1,47 @@
+using System.IO.BACnet.Serialize;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Routed BACnet addresses (NPDU source/destination specifiers) round-trip for any MAC length,
+/// including the 6-byte VMAC/SADR of devices reached through a router (#27).
+/// </summary>
+public class NpduRoutedAddressTests
+{
+    [Theory]
+    [InlineData(1)]   // MS/TP-style 1-byte MAC
+    [InlineData(6)]   // 6-byte VMAC - devices behind a router (#27)
+    [InlineData(18)]  // IPv6-length MAC
+    public void Routed_destination_roundtrips_any_mac_length(int macLen)
+    {
+        var mac = Enumerable.Range(0xA0, macLen).Select(i => (byte)i).ToArray();
+        var dest = new BacnetAddress(BacnetAddressTypes.None, 302, mac);
+
+        var buffer = new EncodeBuffer();
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, dest, null, 0xFF);
+
+        NPDU.Decode(buffer.buffer, 0, out _, out var decoded, out _, out _, out _, out _);
+
+        Assert.NotNull(decoded);
+        Assert.Equal((ushort)302, decoded.net);
+        Assert.Equal(mac, decoded.adr);
+    }
+
+    [Fact]
+    public void Routed_source_roundtrips_6_byte_vmac()
+    {
+        var mac = new byte[] { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+        var source = new BacnetAddress(BacnetAddressTypes.None, 100, mac);
+
+        var buffer = new EncodeBuffer();
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, null, source, 0xFF);
+
+        NPDU.Decode(buffer.buffer, 0, out _, out _, out var decoded, out _, out _, out _);
+
+        Assert.NotNull(decoded);
+        Assert.Equal((ushort)100, decoded.net);
+        Assert.Equal(mac, decoded.adr);
+    }
+}


### PR DESCRIPTION
#27 asked whether 6-byte VMAC/SADR addresses (devices behind a router) are supported. They are in 4.0 — `BacnetAddress` has `net` + arbitrary-length `adr` + `RoutedSource`/`RoutedDestination`, and `NPDU.Encode`/`Decode` read/write the address for any MAC length.

Verified with a round-trip test: a routed destination address with **1-, 6- and 18-byte** MACs, and a 6-byte VMAC source, all survive encode→decode intact (net + MAC bytes).

Closes #27.