### PR TITLE
fix: segmented response conformance and routed I-Am replies

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2740,7 +2740,9 @@ public class BacnetClient : IDisposable
         // below must use the same clamped value on every segment.
         maxApdu = Math.Min(maxApdu, buffer.buffer.Length - buffer.offset);
         buffer.max_offset = buffer.offset + maxApdu;
-        var apduHeader = APDU.EncodeComplexAck(buffer, BacnetPduTypes.PDU_TYPE_COMPLEX_ACK | (isSegmented ? BacnetPduTypes.SEGMENTED_MESSAGE | BacnetPduTypes.SERVER : 0) | (moreFollows ? BacnetPduTypes.MORE_FOLLOWS : 0), service, invokeId, segmentation?.sequence_number ?? 0, segmentation?.window_size ?? 0);
+        // note: no SERVER flag - bits 1-0 of a ComplexACK type octet are
+        // reserved-zero (135 §20.1.5); the server flag only exists in SegmentACK
+        var apduHeader = APDU.EncodeComplexAck(buffer, BacnetPduTypes.PDU_TYPE_COMPLEX_ACK | (isSegmented ? BacnetPduTypes.SEGMENTED_MESSAGE : 0) | (moreFollows ? BacnetPduTypes.MORE_FOLLOWS : 0), service, invokeId, segmentation?.sequence_number ?? 0, segmentation?.window_size ?? 0);
         buffer.min_limit = (maxApdu - apduHeader) * (segmentation?.sequence_number ?? 0);
 
         return buffer;

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -92,6 +92,13 @@ public class BacnetClient : IDisposable
         public byte window_size;
         public byte max_segments;
         // ReSharper restore InconsistentNaming
+
+        /// <summary>
+        /// Max-APDU-length-accepted advertised by the requester whose request
+        /// this response answers. Segments are sized to fit it (135 §5.2.1.2);
+        /// null means unknown and only our own transport limit applies.
+        /// </summary>
+        public BacnetMaxAdpu? RequesterMaxAdpu { get; set; }
     }
 
     private class LastSegmentAck
@@ -206,11 +213,24 @@ public class BacnetClient : IDisposable
     public delegate void AlarmAcknowledgeRequestHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, uint ackProcessIdentifier, BacnetObjectId eventObjectIdentifier, uint eventStateAcked, string ackSource, BacnetGenericTime eventTimeStamp, BacnetGenericTime ackTimeStamp);
     public event AlarmAcknowledgeRequestHandler OnAlarmAcknowledge;
 
+    /// <summary>
+    /// Requester's max-APDU-length-accepted of the confirmed request currently
+    /// being dispatched on this thread, so that GetSegmentBuffer() called from
+    /// inside a request event handler picks it up without every handler
+    /// delegate having to carry the value (135 §5.2.1.2: responses must not
+    /// exceed the requester's max APDU). Thread-static because requests from
+    /// different peers are dispatched concurrently.
+    /// </summary>
+    [ThreadStatic]
+    private static BacnetMaxAdpu? _currentRequestMaxAdpu;
+
     protected void ProcessConfirmedServiceRequest(BacnetAddress address, BacnetPduTypes type, BacnetConfirmedServices service, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, byte invokeId, byte[] buffer, int offset, int length)
     {
         try
         {
             Log.LogDebug($"ConfirmedServiceRequest {service}");
+
+            _currentRequestMaxAdpu = maxAdpu;
 
             raw_buffer = buffer;
             raw_length = length;
@@ -488,6 +508,10 @@ public class BacnetClient : IDisposable
             SendAbort(address, invokeId, BacnetAbortReason.OTHER);
             //ErrorResponse(address, service, invokeId, BacnetErrorClasses.ERROR_CLASS_DEVICE, BacnetErrorCodes.ERROR_CODE_ABORT_OTHER);
             Log.LogError(ex, "Error in ProcessConfirmedServiceRequest");
+        }
+        finally
+        {
+            _currentRequestMaxAdpu = null;
         }
     }
 
@@ -2661,6 +2685,13 @@ public class BacnetClient : IDisposable
 
     public Segmentation GetSegmentBuffer(BacnetMaxSegments maxSegments)
     {
+        // when called from inside a confirmed-request event handler (the usual
+        // pattern), pick up that request's max-APDU-length-accepted
+        return GetSegmentBuffer(maxSegments, _currentRequestMaxAdpu);
+    }
+
+    public Segmentation GetSegmentBuffer(BacnetMaxSegments maxSegments, BacnetMaxAdpu? requesterMaxAdpu)
+    {
         if (maxSegments == BacnetMaxSegments.MAX_SEG0)
             return null;
 
@@ -2668,8 +2699,21 @@ public class BacnetClient : IDisposable
         {
             buffer = GetEncodeBuffer(Transport.HeaderLength),
             max_segments = GetSegmentsCount(maxSegments),
-            window_size = ProposedWindowSize
+            window_size = ProposedWindowSize,
+            RequesterMaxAdpu = requesterMaxAdpu
         };
+    }
+
+    /// <summary>
+    /// APDU size limit for a response: our own transport limit, capped by the
+    /// requester's max-APDU-length-accepted when known (135 §5.2.1.2).
+    /// </summary>
+    private int GetMaxApdu(Segmentation segmentation)
+    {
+        var maxApdu = GetMaxApdu();
+        if (segmentation?.RequesterMaxAdpu != null)
+            maxApdu = Math.Min(maxApdu, GetMaxApdu(segmentation.RequesterMaxAdpu.Value));
+        return maxApdu;
     }
 
     private EncodeBuffer EncodeSegmentHeader(BacnetAddress adr, byte invokeId, Segmentation segmentation, BacnetConfirmedServices service, bool moreFollows)
@@ -2689,9 +2733,15 @@ public class BacnetClient : IDisposable
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
 
         //set segments limits
-        buffer.max_offset = buffer.offset + GetMaxApdu();
+        var maxApdu = GetMaxApdu(segmentation);
+        // never open an encode window past the physical buffer: the APDU limit
+        // can exceed the transport payload (e.g. 1476 vs the default 1472),
+        // which previously wrote out of bounds. The min_limit chunk arithmetic
+        // below must use the same clamped value on every segment.
+        maxApdu = Math.Min(maxApdu, buffer.buffer.Length - buffer.offset);
+        buffer.max_offset = buffer.offset + maxApdu;
         var apduHeader = APDU.EncodeComplexAck(buffer, BacnetPduTypes.PDU_TYPE_COMPLEX_ACK | (isSegmented ? BacnetPduTypes.SEGMENTED_MESSAGE | BacnetPduTypes.SERVER : 0) | (moreFollows ? BacnetPduTypes.MORE_FOLLOWS : 0), service, invokeId, segmentation?.sequence_number ?? 0, segmentation?.window_size ?? 0);
-        buffer.min_limit = (GetMaxApdu() - apduHeader) * (segmentation?.sequence_number ?? 0);
+        buffer.min_limit = (maxApdu - apduHeader) * (segmentation?.sequence_number ?? 0);
 
         return buffer;
     }
@@ -2804,7 +2854,7 @@ public class BacnetClient : IDisposable
             //first segment? validate max segments
             if (segmentation.sequence_number == 0)  //only validate first segment
             {
-                if (segmentation.max_segments != 0xFF && segmentation.buffer.offset > segmentation.max_segments * (GetMaxApdu() - 5))      //5 is adpu header
+                if (segmentation.max_segments != 0xFF && segmentation.buffer.offset > segmentation.max_segments * (GetMaxApdu(segmentation) - 5))      //5 is adpu header
                 {
                     Log.LogInformation("Too much segmenation");
                     // DAL

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1147,18 +1147,25 @@ public class BacnetClient : IDisposable
 
     public void Iam(uint deviceId, BacnetSegmentations segmentation = BacnetSegmentations.SEGMENTATION_BOTH, BacnetAddress receiver = null, BacnetAddress source = null)
     {
+        BacnetAddress npduDestination;
         if (receiver == null)
         {
             receiver = Transport.GetBroadcastAddress();
+            npduDestination = receiver;
             Log.LogDebug($"Broadcasting Iam {deviceId}");
         }
         else
         {
-            Log.LogDebug($"Sending Iam {deviceId} to {receiver}");
+            // answering a Who-Is that came through a BACnet router: the NPDU
+            // destination is the original source network/address while the
+            // frame itself goes back to the router that forwarded it, so the
+            // requester receives the I-Am as 135 §16.10.4 requires
+            npduDestination = receiver.RoutedSource ?? receiver;
+            Log.LogDebug($"Sending Iam {deviceId} to {receiver.ToString(false)}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, receiver, source);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, npduDestination, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_I_AM);
         Services.EncodeIamBroadcast(b, deviceId, (uint)GetMaxApdu(), segmentation, VendorId);
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - Segmented responses now respect the requester's max-APDU-length-accepted (ASHRAE 135 §5.2.1.2). The
   value is captured automatically when `GetSegmentBuffer` is called inside a request event handler, or
   can be passed explicitly via the new `GetSegmentBuffer(maxSegments, requesterMaxAdpu)` overload.
+- Segmented ComplexACKs no longer set the reserved `SERVER` bit in the PDU type octet
+  (ASHRAE 135 §20.1.5 reserves bits 1-0 as zero; strict peers could discard such frames). This aligns
+  the wire format with YABE and bacnet-stack.
 - OS detection in the UDP transport now uses `RuntimeInformation.IsOSPlatform`, fixing `DontFragment` on
   macOS (#91) and making the Windows-only `SIO_UDP_CONNRESET` guard analyzer-clean.
 - Response correlation matches by invoke-id per ASHRAE 135 §20.1.2.6 (#141, #149).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - SharpPcap bumped 4.x → 6.x in `BACnet.Ethernet` (drops the vulnerable transitive log4net).
 
 ### Fixed
+- Segmented responses no longer crash with an `IndexOutOfRangeException` when the APDU limit exceeds
+  the transport payload buffer (the default `maxPayload: 1472` vs the 1476-byte B/IP APDU): the segment
+  encoder clamps its window to the physical buffer and `EncodeBuffer` reports `NotEnoughBuffer` instead
+  of writing out of bounds.
+- Segmented responses now respect the requester's max-APDU-length-accepted (ASHRAE 135 §5.2.1.2). The
+  value is captured automatically when `GetSegmentBuffer` is called inside a request event handler, or
+  can be passed explicitly via the new `GetSegmentBuffer(maxSegments, requesterMaxAdpu)` overload.
 - OS detection in the UDP transport now uses `RuntimeInformation.IsOSPlatform`, fixing `DontFragment` on
   macOS (#91) and making the Windows-only `SIO_UDP_CONNRESET` guard analyzer-clean.
 - Response correlation matches by invoke-id per ASHRAE 135 §20.1.2.6 (#141, #149).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - Multi-targeting: `net48;netstandard2.0;net8.0;net10.0`.
 - New packages: `BACnet.Ethernet`, `BACnet.Serial`, `BACnet.Logging.CommonLogging`.
 - Central Package Management, MinVer tag-driven versioning, Source Link + symbol (`.snupkg`) packages.
+- `BacnetIpUdpProtocolTransport` accepts a `maxApdu` constructor parameter to lower the advertised and
+  sent APDU size (e.g. `MAX_APDU1024` keeps every frame, including segmented responses, under a
+  1500-byte MTU instead of relying on IP fragmentation).
 - CI: multi-OS build matrix; tag-triggered publish to both nuget.org (Trusted Publishing) and GitHub Packages.
 - Runnable sample projects moved in-repo under `Examples/` and built in CI.
 - ASHRAE 135 Annex F golden-vector encode/decode tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - Segmented responses now respect the requester's max-APDU-length-accepted (ASHRAE 135 §5.2.1.2). The
   value is captured automatically when `GetSegmentBuffer` is called inside a request event handler, or
   can be passed explicitly via the new `GetSegmentBuffer(maxSegments, requesterMaxAdpu)` overload.
+- `Iam()` can now answer a Who-Is that arrived through a BACnet router: when the receiver address
+  carries a `RoutedSource`, the I-Am is NPDU-addressed to the original source network and sent back via
+  the router, so the requester receives it as ASHRAE 135 §16.10.4 requires (previously such replies
+  were mis-addressed and never reached the requester).
 - Segmented ComplexACKs no longer set the reserved `SERVER` bit in the PDU type octet
   (ASHRAE 135 §20.1.5 reserves bits 1-0 as zero; strict peers could discard such frames). This aligns
   the wire format with YABE and bacnet-stack.

--- a/Serialize/EncodeBuffer.cs
+++ b/Serialize/EncodeBuffer.cs
@@ -46,7 +46,15 @@ public class EncodeBuffer
         if (offset < max_offset)
         {
             if (serialize_counter >= min_limit)
-                buffer[offset] = b;
+            {
+                // max_offset may have been raised beyond the physical buffer
+                // (e.g. a segment window larger than the transport payload):
+                // flag it instead of throwing IndexOutOfRangeException
+                if (offset < buffer.Length)
+                    buffer[offset] = b;
+                else
+                    result |= EncodeResult.NotEnoughBuffer;
+            }
         }
         else
         {

--- a/Tests/BacnetClientIamTests.cs
+++ b/Tests/BacnetClientIamTests.cs
@@ -1,0 +1,71 @@
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// I-Am addressing: a receiver that carries a RoutedSource (a Who-Is that came
+/// through a BACnet router) must produce an I-Am whose NPDU destination is the
+/// original source network/address while the frame goes back to the router.
+/// </summary>
+public class BacnetClientIamTests
+{
+    [Fact]
+    public void Iam_to_routed_receiver_targets_original_source_via_router()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        var sourceMac = new byte[] { 172, 28, 1, 20, 0xBA, 0xC0 };
+        var router = new BacnetAddress(BacnetAddressTypes.IP, "172.28.2.10:47808")
+        {
+            RoutedSource = new BacnetAddress(BacnetAddressTypes.None, 1, sourceMac)
+        };
+
+        client.Iam(1234, receiver: router);
+
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Same(router, sentTo); // datalink frame goes to the router
+
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.NotNull(destination); // NPDU carries DNET/DADR of the original source
+        Assert.Equal((ushort)1, destination.net);
+        Assert.Equal(sourceMac, destination.adr);
+    }
+
+    [Fact]
+    public void Iam_to_local_receiver_has_no_npdu_destination()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        var receiver = new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.2:47808");
+        client.Iam(1234, receiver: receiver);
+
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Same(receiver, sentTo);
+
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.Null(destination);
+    }
+
+    [Fact]
+    public void Iam_without_receiver_broadcasts_locally()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        client.Iam(1234);
+
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Equal(transport.GetBroadcastAddress(), sentTo);
+
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.Null(destination);
+    }
+}

--- a/Tests/BacnetClientSegmentationTests.cs
+++ b/Tests/BacnetClientSegmentationTests.cs
@@ -72,6 +72,9 @@ public class BacnetClientSegmentationTests
 
             var type = (BacnetPduTypes)frame[npduLen];
             Assert.True((type & BacnetPduTypes.SEGMENTED_MESSAGE) > 0, "every frame should be a segment");
+            // bits 1-0 of a ComplexACK type octet are reserved and must be 0
+            // (135 §20.1.5) - the SERVER flag belongs to SegmentACK only
+            Assert.Equal(0, (byte)type & 0x03);
             Assert.Equal(expectedSequence, frame[npduLen + 2]);
             expectedSequence++;
 

--- a/Tests/BacnetClientSegmentationTests.cs
+++ b/Tests/BacnetClientSegmentationTests.cs
@@ -1,0 +1,158 @@
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Segmented ComplexACK transmission: segments must respect the requester's
+/// max-APDU-length-accepted (135 §5.2.1), must never write past the transport
+/// buffer (previously an IndexOutOfRangeException with the default 1472-byte
+/// payload), and the reassembled segments must equal the unsegmented encoding.
+/// </summary>
+public class BacnetClientSegmentationTests
+{
+    private static readonly BacnetObjectId TestObject = new(BacnetObjectTypes.OBJECT_DEVICE, 1234);
+    private static readonly BacnetPropertyReference TestProperty =
+        new((uint)BacnetPropertyIds.PROP_DESCRIPTION, ASN1.BACNET_ARRAY_ALL);
+
+    private static BacnetValue MakeValue(int payloadLength)
+    {
+        var text = new StringBuilder(payloadLength);
+        while (text.Length < payloadLength)
+            text.Append("0123456789");
+        return new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_CHARACTER_STRING,
+            text.ToString(0, payloadLength));
+    }
+
+    private static byte[] ReferenceEncoding(BacnetValue value)
+    {
+        var buffer = new EncodeBuffer(); // expandable
+        Services.EncodeReadPropertyAcknowledge(buffer, TestObject,
+            TestProperty.propertyIdentifier, TestProperty.propertyArrayIndex, new[] { value });
+        return buffer.ToArray();
+    }
+
+    private static List<byte[]> WaitForCompleteResponse(RecordingTransport transport)
+    {
+        var watch = Stopwatch.StartNew();
+        while (watch.ElapsedMilliseconds < 5000)
+        {
+            lock (transport.Sent)
+            {
+                var complexAcks = transport.Sent
+                    .Select(s => s.Frame)
+                    .Where(f => ((BacnetPduTypes)f[2] & BacnetPduTypes.PDU_TYPE_MASK) == BacnetPduTypes.PDU_TYPE_COMPLEX_ACK)
+                    .ToList();
+                if (complexAcks.Count > 0 &&
+                    ((BacnetPduTypes)complexAcks[complexAcks.Count - 1][2] & BacnetPduTypes.MORE_FOLLOWS) == 0)
+                    return complexAcks;
+            }
+            Thread.Sleep(20);
+        }
+        Assert.Fail("segmented response did not complete within 5 s");
+        return null;
+    }
+
+    private static byte[] Reassemble(IEnumerable<byte[]> frames, out int maxApduLength)
+    {
+        var content = new List<byte>();
+        var expectedSequence = 0;
+        maxApduLength = 0;
+        foreach (var frame in frames)
+        {
+            var npduLen = NPDU.Decode(frame, 0, out _, out _, out _, out _, out _, out _);
+            var apduLength = frame.Length - npduLen;
+            maxApduLength = Math.Max(maxApduLength, apduLength);
+
+            var type = (BacnetPduTypes)frame[npduLen];
+            Assert.True((type & BacnetPduTypes.SEGMENTED_MESSAGE) > 0, "every frame should be a segment");
+            Assert.Equal(expectedSequence, frame[npduLen + 2]);
+            expectedSequence++;
+
+            // [type][invoke-id][sequence][window][service-choice] payload
+            content.AddRange(frame.Skip(npduLen + 5));
+        }
+        return content.ToArray();
+    }
+
+    [Fact]
+    public void Segments_respect_requester_max_apdu()
+    {
+        var transport = new RecordingTransport(maxPayload: 1472, maxApdu: BacnetMaxAdpu.MAX_APDU1476)
+        {
+            AutoSegmentAck = true
+        };
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        var adr = new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.2:47808");
+        var value = MakeValue(3000);
+        var segmentation = client.GetSegmentBuffer(BacnetMaxSegments.MAX_SEG16, BacnetMaxAdpu.MAX_APDU480);
+
+        client.ReadPropertyResponse(adr, 1, segmentation, TestObject, TestProperty, new[] { value });
+
+        var frames = WaitForCompleteResponse(transport);
+        var reassembled = Reassemble(frames, out var maxApduLength);
+
+        Assert.InRange(maxApduLength, 1, 480);
+        Assert.Equal(ReferenceEncoding(value), reassembled);
+    }
+
+    [Fact]
+    public void Segmented_response_fits_default_transport_buffer_without_throwing()
+    {
+        // default maxPayload (1472) is smaller than the 1476 APDU limit:
+        // this combination previously crashed the segment encoder with an
+        // IndexOutOfRangeException on the first oversized response
+        var transport = new RecordingTransport(maxPayload: 1472, maxApdu: BacnetMaxAdpu.MAX_APDU1476)
+        {
+            AutoSegmentAck = true
+        };
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        var adr = new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.2:47808");
+        var value = MakeValue(4000);
+        var segmentation = client.GetSegmentBuffer(BacnetMaxSegments.MAX_SEG16, null);
+
+        client.ReadPropertyResponse(adr, 1, segmentation, TestObject, TestProperty, new[] { value });
+
+        var frames = WaitForCompleteResponse(transport);
+        var reassembled = Reassemble(frames, out var maxApduLength);
+
+        Assert.InRange(maxApduLength, 1, transport.MaxBufferLength);
+        Assert.Equal(ReferenceEncoding(value), reassembled);
+    }
+
+    [Fact]
+    public void GetSegmentBuffer_inside_request_handler_captures_requester_max_apdu()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        BacnetClient.Segmentation captured = null;
+        client.OnReadPropertyRequest += (sender, adr, invokeId, objectId, property, maxSegments) =>
+        {
+            captured = sender.GetSegmentBuffer(maxSegments);
+        };
+        client.Start();
+
+        var request = new EncodeBuffer(new byte[64], 0);
+        NPDU.Encode(request, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, null);
+        APDU.EncodeConfirmedServiceRequest(request,
+            BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST | BacnetPduTypes.SEGMENTED_RESPONSE_ACCEPTED,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY,
+            BacnetMaxSegments.MAX_SEG16, BacnetMaxAdpu.MAX_APDU480, 1);
+        Services.EncodeReadProperty(request, TestObject, (uint)BacnetPropertyIds.PROP_OBJECT_NAME);
+
+        transport.Receive(request.ToArray(), new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.2:47808"));
+
+        Assert.NotNull(captured);
+        Assert.Equal(BacnetMaxAdpu.MAX_APDU480, captured.RequesterMaxAdpu);
+    }
+}

--- a/Tests/Serialize/EncodeBufferTests.cs
+++ b/Tests/Serialize/EncodeBufferTests.cs
@@ -1,0 +1,36 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// A fixed-size EncodeBuffer whose max_offset was raised past the physical
+/// array (the segment encoder does this when the APDU limit exceeds the
+/// transport payload) must flag NotEnoughBuffer instead of throwing.
+/// </summary>
+public class EncodeBufferTests
+{
+    [Fact]
+    public void Add_beyond_physical_buffer_flags_NotEnoughBuffer_instead_of_throwing()
+    {
+        var buffer = new EncodeBuffer(new byte[8], 0) { max_offset = 12 };
+
+        for (var i = 0; i < 12; i++)
+            buffer.Add((byte)i);
+
+        Assert.True((buffer.result & EncodeResult.NotEnoughBuffer) > 0);
+        Assert.Equal(new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, buffer.buffer);
+    }
+
+    [Fact]
+    public void Add_within_buffer_and_max_offset_stays_Good()
+    {
+        var buffer = new EncodeBuffer(new byte[8], 0);
+
+        for (var i = 0; i < 8; i++)
+            buffer.Add((byte)i);
+
+        Assert.Equal(EncodeResult.Good, buffer.result);
+        Assert.Equal(8, buffer.GetLength());
+    }
+}

--- a/Tests/Support/RecordingTransport.cs
+++ b/Tests/Support/RecordingTransport.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Serialize;
+
+namespace System.IO.BACnet.Tests.Support;
+
+/// <summary>
+/// In-memory transport: records every frame passed to <see cref="Send"/> and
+/// lets tests inject incoming frames. With <see cref="AutoSegmentAck"/> it
+/// acknowledges each segmented ComplexACK like a remote requester would, so
+/// segmented responses run to completion without a network.
+/// </summary>
+public class RecordingTransport : BacnetTransportBase
+{
+    public List<(byte[] Frame, BacnetAddress Address)> Sent { get; } = [];
+    public bool AutoSegmentAck { get; set; }
+
+    public RecordingTransport(int maxPayload = 1472, BacnetMaxAdpu maxApdu = BacnetMaxAdpu.MAX_APDU1476)
+    {
+        Type = BacnetAddressTypes.IP;
+        HeaderLength = 0;
+        MaxBufferLength = maxPayload;
+        MaxAdpuLength = maxApdu;
+    }
+
+    public override void Start()
+    {
+    }
+
+    public override BacnetAddress GetBroadcastAddress()
+    {
+        return new BacnetAddress(BacnetAddressTypes.IP, "255.255.255.255:47808");
+    }
+
+    public override int Send(byte[] buffer, int offset, int dataLength, BacnetAddress address, bool waitForTransmission, int timeout)
+    {
+        var frame = new byte[dataLength];
+        Array.Copy(buffer, offset, frame, 0, dataLength);
+        lock (Sent)
+        {
+            Sent.Add((frame, address));
+        }
+
+        if (AutoSegmentAck)
+            AckIfSegmented(frame, address);
+
+        return dataLength;
+    }
+
+    /// <summary>Inject a frame as if it arrived from <paramref name="source"/>.</summary>
+    public void Receive(byte[] frame, BacnetAddress source)
+    {
+        InvokeMessageRecieved(frame, 0, frame.Length, source);
+    }
+
+    private void AckIfSegmented(byte[] frame, BacnetAddress address)
+    {
+        var npduLen = NPDU.Decode(frame, 0, out var function, out _, out _, out _, out _, out _);
+        if (npduLen <= 0 || function.HasFlag(BacnetNpduControls.NetworkLayerMessage))
+            return;
+
+        var pduType = (BacnetPduTypes)frame[npduLen];
+        if ((pduType & BacnetPduTypes.PDU_TYPE_MASK) != BacnetPduTypes.PDU_TYPE_COMPLEX_ACK ||
+            (pduType & BacnetPduTypes.SEGMENTED_MESSAGE) == 0)
+            return;
+
+        var invokeId = frame[npduLen + 1];
+        var sequenceNumber = frame[npduLen + 2];
+
+        // reply like the requester: ack this segment, actual window size 1
+        var buffer = new EncodeBuffer(new byte[16], 0);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, null);
+        APDU.EncodeSegmentAck(buffer, BacnetPduTypes.PDU_TYPE_SEGMENT_ACK, invokeId, sequenceNumber, 1);
+
+        // fresh address instance: OnRecieve mutates RoutedSource on it
+        Receive(buffer.ToArray(), new BacnetAddress(address.type, address.ToString()));
+    }
+
+    public override void Dispose()
+    {
+    }
+}

--- a/Transport/BacnetIpUdpProtocolTransport.cs
+++ b/Transport/BacnetIpUdpProtocolTransport.cs
@@ -63,14 +63,21 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
     // Some more complex solutions could avoid this, that's why this property is virtual
     public virtual IPEndPoint LocalEndPoint => (IPEndPoint)_exclusiveConn.Client.LocalEndPoint;
 
+    /// <param name="maxApdu">
+    /// Largest APDU this endpoint sends and advertises (in I-Am and confirmed
+    /// request headers). The default <see cref="BVLC.BVLC_MAX_APDU"/> (1476)
+    /// predates UDP/IP overhead, so full-size frames exceed a 1500-byte MTU
+    /// and get IP-fragmented; pass <see cref="BacnetMaxAdpu.MAX_APDU1024"/> to
+    /// keep every frame, including segmented responses, below the MTU.
+    /// </param>
     public BacnetIpUdpProtocolTransport(int port, bool useExclusivePort = false, bool dontFragment = false,
-        int maxPayload = 1472, string localEndpointIp = "")
+        int maxPayload = 1472, string localEndpointIp = "", BacnetMaxAdpu maxApdu = BVLC.BVLC_MAX_APDU)
     {
         SharedPort = port;
         MaxBufferLength = maxPayload;
         Type = BacnetAddressTypes.IP;
         HeaderLength = BVLC.BVLC_HEADER_LENGTH;
-        MaxAdpuLength = BVLC.BVLC_MAX_APDU;
+        MaxAdpuLength = maxApdu;
 
         _exclusivePort = useExclusivePort;
         _dontFragment = dontFragment;
@@ -78,8 +85,8 @@ public class BacnetIpUdpProtocolTransport : BacnetTransportBase
     }
 
     public BacnetIpUdpProtocolTransport(int sharedPort, int exclusivePort, bool dontFragment = false,
-        int maxPayload = 1472, string localEndpointIp = "")
-        : this(sharedPort, false, dontFragment, maxPayload, localEndpointIp)
+        int maxPayload = 1472, string localEndpointIp = "", BacnetMaxAdpu maxApdu = BVLC.BVLC_MAX_APDU)
+        : this(sharedPort, false, dontFragment, maxPayload, localEndpointIp, maxApdu)
     {
         ExclusivePort = exclusivePort;
     }


### PR DESCRIPTION
Four conformance/robustness fixes in the segmented-response encoder, I-Am addressing and the BACnet/IP transport, found while interop-testing this library against bacnet-stack 1.5.0 through a BACnet router (two isolated BACnet/IP networks, DNET 1 ↔ DNET 2).

## Changes

1. **Segment sizing** (`fix`): the segment encoder opened its window at `offset + GetMaxApdu()` regardless of the physical transport buffer (default `maxPayload: 1472` vs the 1476-octet B/IP APDU), throwing `IndexOutOfRangeException` on the first segmented response — and sized segments only by the local transport limit, ignoring the requester's max-APDU-length-accepted. Per **ASHRAE 135 §5.2.1.2** the APDU shall be the smallest of the local limit (a), what the internetwork conveys (b) and what the peer accepts (c); for ComplexACKs (c) comes from the request header. Segments now honor all of it; the requester value is captured automatically when `GetSegmentBuffer(maxSegments)` is called inside a request event handler (thread-static, so existing handlers become conformant with zero changes), or passed explicitly via the new `GetSegmentBuffer(maxSegments, requesterMaxAdpu)` overload. `EncodeBuffer` additionally reports `NotEnoughBuffer` instead of writing out of bounds.
2. **Reserved bits** (`fix`): segmented ComplexACKs carried the `SERVER` flag in the PDU type octet. **§20.1.5**: `reserved [3] Unsigned (0..3) -- shall be set to zero`; the server flag exists only in SegmentACK PDUs. YABE and bacnet-stack both encode these bits as zero. (Checked all published addenda through 135-2024cu — the bits remain unclaimed, so clearing them is also forward-compatible.)
3. **Routed I-Am** (`fix`): `Iam()` used the receiver address as both NPDU destination and datalink destination, so a reply to a Who-Is forwarded by a router died at the router. **§16.10.4**: the I-Am "shall be sent in such a manner that the BACnet-user that sent the Who-Is will receive the resulting I-Am". With a `RoutedSource` on the receiver, the I-Am is now NPDU-addressed to the original source and sent back through the router — the same behaviour as bacnet-stack's BTL-tested `Send_I_Am_Unicast`.
4. **MTU-safe max APDU** (`new`): `BacnetIpUdpProtocolTransport` gets a `maxApdu` constructor parameter. The 1476 default predates UDP/IP overhead, so full-size frames exceed a 1500-byte MTU and rely on IP fragmentation; `MAX_APDU1024` keeps every frame under the MTU. `MaxAdpuLength` drives both the I-Am advertisement and segment sizing, so the endpoint stays self-consistent.

## Verification

**Unit tests**: 8 new (`EncodeBufferTests`, `BacnetClientSegmentationTests` with a full segmented round-trip over an in-memory transport, `BacnetClientIamTests`). Each commit builds and passes the suite independently (128/128 → 131/131).

**Container before/after matrix** — executed against the **branch tip** (`dotnet pack` of commit `0d34744` → MinVer `4.0.0-beta.1.14`) vs the **published `4.0.0-beta.1`** from nuget.org. The library version under test is printed by the device on startup in every run.

```mermaid
flowchart LR
    C["client container<br/>bacnet-stack 1.5.0<br/>bacrpr: ReadProperty client<br/>+ segment reassembly"]
    R["router container<br/>bacnet-stack 1.5.0 router app<br/>172.28.1.10 / 172.28.2.10"]
    D["device container<br/>BACnet .NET, this PR vs beta.1<br/>device 1234, 800 analog-values"]
    C <-->|"bacnet-net1 bridge<br/>172.28.1.0/24<br/>BACnet DNET 1, udp/47808"| R
    R <-->|"bacnet-net2 bridge<br/>172.28.2.0/24<br/>BACnet DNET 2, udp/47808"| D
```

The two Docker bridge networks are isolated from each other, so the only path between client and device is the BACnet router container — the tests cannot pass via direct IP.

| Fix | Test | `4.0.0-beta.1` (before) | `4.0.0-beta.1.14` = this PR (after) |
|---|---|---|---|
| 1 | object-list read (~4 kB), default transport | ❌ `IndexOutOfRangeException`, client gets `BACnet Error: services: other` | ✅ 3 segments (1451 B, buffer-clamped), value decoded |
| 1 | client advertises max-APDU 480 | ❌ segments of **1471 B** | ✅ 9 segments of **≤475 B** |
| 2 | type octet of every segment | ❌ `0x3D` / `0x39` (reserved bit set) | ✅ `0x3C` / `0x38` |
| 4 | router IP-fragmentation counters across a read | ❌ `ReasmReqds +4, FragCreates +4` (with the old `maxPayload: 1600` workaround) | ✅ `maxApdu: 1024` → 4 segments ≤1019 B, all counters **+0** |
| 3 | Who-Is via router → I-Am → read | ❌ `APDU Timeout!` (I-Am dies at the router) | ✅ binds through the router, reads the value |

Note: the before-rows for fixes 1 (480), 2 and 4 required the old `maxPayload: 1600` workaround so beta.1 could segment at all — on beta.1 one must choose between crashing (fix 1) and IP fragmentation (fix 4).

<details>
<summary>Raw console output — before (published 4.0.0-beta.1)</summary>

```
Transport: maxPayload=1472, maxApdu=MAX_APDU1476
BACnet device 1234 (NuGet BACnet 4.0.0-beta.1) listening on udp/47808

# object-list, default transport
Sending ReadProperty device 1234 object-list (segmented response accepted, max 16 segments, max APDU 1476) ...
BACnet Error: services: other
device log: ReadProperty failed: Index was outside the bounds of the array.

# dynamic discovery via router
Using dynamic binding: broadcasting Who-Is for device 1234.
Error: APDU Timeout!
device log: Who-Is [1234..1234] received, I-Am sent - never crosses the router

# --max-apdu 480 (device restarted with TRANSPORT_MAX_PAYLOAD=1600 workaround)
Transport: maxPayload=1600, maxApdu=MAX_APDU1476
Sending ReadProperty device 1234 object-list (segmented response accepted, max 16 segments, max APDU 480) ...
Segment 0 received (1471 bytes, type octet 0x3D)
Segment 1 received (1471 bytes, type octet 0x3D)
Segment 2 received (1072 bytes, type octet 0x39) - last
Reassembled 3 segments, 4014 bytes of service data.
router IP frag counters delta: ReasmReqds +4  ReasmOKs +2  FragCreates +4
```
</details>

<details>
<summary>Raw console output — after (this PR, 4.0.0-beta.1.14)</summary>

```
Transport: maxPayload=1472, maxApdu=MAX_APDU1476
BACnet device 1234 (NuGet BACnet 4.0.0-beta.1.14) listening on udp/47808

# object-list, default transport (no workaround)
Segment 0 received (1451 bytes, type octet 0x3C)
Segment 1 received (1451 bytes, type octet 0x3C)
Segment 2 received (1112 bytes, type octet 0x38) - last
Reassembled 3 segments, 4014 bytes of service data.
Success: value read through the BACnet router using 3-segment response.

# --max-apdu 480
Segment 0..7 received (475 bytes each, type octet 0x3C)
Segment 8 received (214 bytes, type octet 0x38) - last
Reassembled 9 segments, 4014 bytes of service data.
Success: value read through the BACnet router using 9-segment response.

# dynamic discovery via router
Using dynamic binding: broadcasting Who-Is for device 1234.
Bound to device 1234: next-hop 172.28.1.10:47808, DNET 2, DADR 172.28.2.20:47808 (reached through a BACnet router)
"BACnet interop lab device"
Success: value read through the BACnet router.

# maxApdu: 1024 via the new ctor parameter
Transport: maxPayload=1472, maxApdu=MAX_APDU1024
Segment 0 received (1019 bytes, type octet 0x3C)
Segment 1 received (1019 bytes, type octet 0x3C)
Segment 2 received (1019 bytes, type octet 0x3C)
Segment 3 received (957 bytes, type octet 0x38) - last
Reassembled 4 segments, 4014 bytes of service data.
router IP frag counters delta: ReasmReqds +0  ReasmOKs +0  FragCreates +0
```
</details>

Also compared against YABE trunk (r642) and downstream forks: none solve these; YABE's unicast reply pattern and bacnet-stack's `Send_I_Am_Unicast` ("must direct back to src->net to meet BTL tests") match the approach taken here.

## Notes for review

- The thread-static capture in `ProcessConfirmedServiceRequest` covers the universal synchronous-handler pattern; handlers that respond asynchronously should use the explicit overload. The alternative — adding `maxAdpu` to every per-service delegate — would break every handler signature.
- With default settings, segment payloads shrink slightly (1451 vs 1476 content bytes) because the encoder now respects the 1472-byte buffer instead of crashing.
- Follow-up candidates (not in this PR): apply the routed-destination treatment to other unconfirmed senders (`WhoIs`, `IHave`, …); consult the peer's `Max_APDU_Length_Accepted` Device property for >1476 APDUs if BACnet/SC (Addendum 135-2016bj) support is ever added.
