### PR TITLE
new: ConfirmedPrivateTransfer / UnconfirmedPrivateTransfer support in BacnetClient

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -475,6 +475,16 @@ public class BacnetClient : IDisposable
                     Log.LogWarning("Couldn't decode AlarmAcknowledge");
                 }
             }
+            else if (service == BacnetConfirmedServices.SERVICE_CONFIRMED_PRIVATE_TRANSFER && OnPrivateTransfer != null)
+            {
+                if (Services.DecodePrivateTransfer(buffer, offset, length, out var vendorId, out var serviceNumber, out var serviceParameters) >= 0)
+                    OnPrivateTransfer(this, address, invokeId, vendorId, serviceNumber, serviceParameters, true, maxSegments);
+                else
+                {
+                    SendAbort(address, invokeId, BacnetAbortReason.OTHER);
+                    Log.LogWarning("Couldn't decode PrivateTransfer");
+                }
+            }
             else
             {
                 // DAL
@@ -505,6 +515,9 @@ public class BacnetClient : IDisposable
     //used by both 'confirmed' and 'unconfirmed' notify
     public delegate void COVNotificationHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, uint subscriberProcessIdentifier, BacnetObjectId initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, bool needConfirm, ICollection<BacnetPropertyValue> values, BacnetMaxSegments maxSegments);
     public event COVNotificationHandler OnCOVNotification;
+
+    public delegate void PrivateTransferHandler(BacnetClient sender, BacnetAddress adr, byte invokeId, uint vendorId, uint serviceNumber, byte[] serviceParameters, bool needConfirm, BacnetMaxSegments maxSegments);
+    public event PrivateTransferHandler OnPrivateTransfer;
 
     protected void ProcessUnconfirmedServiceRequest(BacnetAddress address, BacnetPduTypes type, BacnetUnconfirmedServices service, byte[] buffer, int offset, int length)
     {
@@ -561,6 +574,13 @@ public class BacnetClient : IDisposable
                     OnEventNotify(this, address, 0, eventData, false);
                 else
                     Log.LogWarning("Couldn't decode unconfirmed Event/Alarm Notification");
+            }
+            else if (service == BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_PRIVATE_TRANSFER && OnPrivateTransfer != null)
+            {
+                if (Services.DecodePrivateTransfer(buffer, offset, length, out var vendorId, out var serviceNumber, out var serviceParameters) >= 0)
+                    OnPrivateTransfer(this, address, 0, vendorId, serviceNumber, serviceParameters, false, BacnetMaxSegments.MAX_SEG0);
+                else
+                    Log.LogWarning("Couldn't decode unconfirmed PrivateTransfer");
             }
             else
             {
@@ -1193,6 +1213,17 @@ public class BacnetClient : IDisposable
         NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_EVENT_NOTIFICATION);
         Services.EncodeEventNotifyUnconfirmed(b, eventData);
+        Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
+    }
+
+    public void SendUnconfirmedPrivateTransfer(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters = null, BacnetAddress source = null)
+    {
+        Log.LogDebug($"Sending UnconfirmedPrivateTransfer vendor {vendorId} service {serviceNumber}");
+
+        var b = GetEncodeBuffer(Transport.HeaderLength);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
+        APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_PRIVATE_TRANSFER);
+        Services.EncodePrivateTransferUnconfirmed(b, vendorId, serviceNumber, serviceParameters);
         Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
     }
 
@@ -2320,6 +2351,68 @@ public class BacnetClient : IDisposable
         res.Dispose();
     }
 
+    public bool PrivateTransferRequest(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, out byte[] resultBlock, byte invokeId = 0)
+    {
+        using (var result = (BacnetAsyncResult)BeginPrivateTransferRequest(adr, vendorId, serviceNumber, serviceParameters, true, invokeId))
+        {
+            for (var r = 0; r < _retries; r++)
+            {
+                if (result.WaitForDone(Timeout))
+                {
+                    EndPrivateTransferRequest(result, out _, out _, out resultBlock, out var ex);
+                    if (ex != null)
+                        throw ex;
+                    return true;
+                }
+                if (r < Retries - 1)
+                    result.Resend();
+            }
+        }
+        resultBlock = null;
+        return false;
+    }
+
+    public IAsyncResult BeginPrivateTransferRequest(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, bool waitForTransmit, byte invokeId = 0)
+    {
+        Log.LogDebug($"Sending PrivateTransferRequest vendor {vendorId} service {serviceNumber}");
+        if (invokeId == 0)
+            invokeId = (byte)Interlocked.Increment(ref _invokeId);
+
+        var buffer = GetEncodeBuffer(Transport.HeaderLength);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
+        APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_PRIVATE_TRANSFER, MaxSegments, Transport.MaxAdpuLength, invokeId);
+        Services.EncodePrivateTransferConfirmed(buffer, vendorId, serviceNumber, serviceParameters);
+
+        var ret = new BacnetAsyncResult(this, adr, invokeId, buffer.buffer, buffer.offset - Transport.HeaderLength, waitForTransmit, TransmitTimeout);
+        ret.Resend();
+
+        return ret;
+    }
+
+    public void EndPrivateTransferRequest(IAsyncResult result, out uint vendorId, out uint serviceNumber, out byte[] resultBlock, out Exception ex)
+    {
+        var res = (BacnetAsyncResult)result;
+
+        ex = null;
+        if (!res.WaitForDone(Timeout))
+            ex = new Exception("Wait Timeout");
+
+        if (ex == null)
+            ex = res.Error;
+
+        vendorId = 0;
+        serviceNumber = 0;
+        resultBlock = null;
+
+        if (ex == null)
+        {
+            if (Services.DecodePrivateTransfer(res.Result, 0, res.Result.Length, out vendorId, out serviceNumber, out resultBlock) < 0)
+                ex = new Exception("Decode");
+        }
+
+        res.Dispose();
+    }
+
     // FChaxel
     public bool GetAlarmSummaryOrEventRequest(BacnetAddress adr, bool getEvent, ref IList<BacnetGetEventInformationData> alarms, byte invokeId = 0)
     {
@@ -2887,6 +2980,17 @@ public class BacnetClient : IDisposable
         });
     }
 
+    public void PrivateTransferResponse(BacnetAddress adr, byte invokeId, Segmentation segmentation, uint vendorId, uint serviceNumber, byte[] resultBlock = null)
+    {
+        HandleSegmentationResponse(adr, invokeId, segmentation, o =>
+        {
+            SendComplexAck(adr, invokeId, segmentation, BacnetConfirmedServices.SERVICE_CONFIRMED_PRIVATE_TRANSFER, b =>
+            {
+                Services.EncodePrivateTransferAcknowledge(b, vendorId, serviceNumber, resultBlock);
+            });
+        });
+    }
+
     public void ErrorResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode)
     {
         Log.LogDebug($"Sending ErrorResponse for {service}: {errorCode}");
@@ -2894,6 +2998,16 @@ public class BacnetClient : IDisposable
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR, service, invokeId);
         Services.EncodeError(buffer, errorClass, errorCode);
+        Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.offset - Transport.HeaderLength, adr, false, 0);
+    }
+
+    public void PrivateTransferErrorResponse(BacnetAddress adr, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, uint vendorId, uint serviceNumber, byte[] errorParameters = null)
+    {
+        Log.LogDebug($"Sending PrivateTransferErrorResponse: {errorCode}");
+        var buffer = GetEncodeBuffer(Transport.HeaderLength);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
+        APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR, BacnetConfirmedServices.SERVICE_CONFIRMED_PRIVATE_TRANSFER, invokeId);
+        Services.EncodePrivateTransferError(buffer, errorClass, errorCode, vendorId, serviceNumber, errorParameters);
         Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.offset - Transport.HeaderLength, adr, false, 0);
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - CI: multi-OS build matrix; tag-triggered publish to both nuget.org (Trusted Publishing) and GitHub Packages.
 - Runnable sample projects moved in-repo under `Examples/` and built in CI.
 - ASHRAE 135 Annex F golden-vector encode/decode tests.
+- PrivateTransfer send/receive support in `BacnetClient` (#154): `PrivateTransferRequest`,
+  `SendUnconfirmedPrivateTransfer`, the `OnPrivateTransfer` event, and the
+  `PrivateTransferResponse` / `PrivateTransferErrorResponse` replies (ASHRAE 135 clauses 16.2/16.3).
 
 ### Changed
 - The core package is now pure-managed with no native dependencies (closes the pcap → log4net chain, #112).

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -1440,36 +1440,138 @@ public class Services
         ASN1.encode_context_object_id(buffer, 3, targetObject.type, targetObject.instance);
     }
 
-    public static void EncodePrivateTransferConfirmed(EncodeBuffer buffer, uint vendorID, uint serviceNumber, byte[] data)
+    private static void EncodePrivateTransferData(EncodeBuffer buffer, uint vendorId, uint serviceNumber, byte[] data)
     {
-        ASN1.encode_context_unsigned(buffer, 0, vendorID);
-        ASN1.encode_context_unsigned(buffer, 1, serviceNumber);
-        ASN1.encode_opening_tag(buffer, 2);
-        buffer.Add(data, data.Length);
-        ASN1.encode_closing_tag(buffer, 2);
-    }
-
-    public static void EncodePrivateTransferUnconfirmed(EncodeBuffer buffer, uint vendorID, uint serviceNumber, byte[] data)
-    {
-        ASN1.encode_context_unsigned(buffer, 0, vendorID);
-        ASN1.encode_context_unsigned(buffer, 1, serviceNumber);
-        ASN1.encode_opening_tag(buffer, 2);
-        buffer.Add(data, data.Length);
-        ASN1.encode_closing_tag(buffer, 2);
-    }
-
-    public static void EncodePrivateTransferAcknowledge(EncodeBuffer buffer, uint vendorID, uint serviceNumber, byte[] data)
-    {
-        ASN1.encode_context_unsigned(buffer, 0, vendorID);
+        ASN1.encode_context_unsigned(buffer, 0, vendorId);
         ASN1.encode_context_unsigned(buffer, 1, serviceNumber);
 
-        // The result block is optional; omit it (rather than NRE / emit an empty [2]) when absent.
         if (data == null || data.Length == 0)
             return;
 
         ASN1.encode_opening_tag(buffer, 2);
         buffer.Add(data, data.Length);
         ASN1.encode_closing_tag(buffer, 2);
+    }
+
+    public static void EncodePrivateTransferConfirmed(EncodeBuffer buffer, uint vendorId, uint serviceNumber, byte[] data)
+    {
+        EncodePrivateTransferData(buffer, vendorId, serviceNumber, data);
+    }
+
+    public static void EncodePrivateTransferUnconfirmed(EncodeBuffer buffer, uint vendorId, uint serviceNumber, byte[] data)
+    {
+        EncodePrivateTransferData(buffer, vendorId, serviceNumber, data);
+    }
+
+    public static void EncodePrivateTransferAcknowledge(EncodeBuffer buffer, uint vendorId, uint serviceNumber, byte[] data)
+    {
+        EncodePrivateTransferData(buffer, vendorId, serviceNumber, data);
+    }
+
+    public static int DecodePrivateTransfer(byte[] buffer, int offset, int apduLen, out uint vendorId, out uint serviceNumber, out byte[] data)
+    {
+        var len = 0;
+        uint lenValueType;
+
+        vendorId = 0;
+        serviceNumber = 0;
+        data = null;
+
+        /* Tag 0: vendor-id */
+        if (!ASN1.decode_is_context_tag(buffer, offset + len, 0))
+            return -1;
+        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out _, out lenValueType);
+        len += ASN1.decode_unsigned(buffer, offset + len, lenValueType, out vendorId);
+
+        /* Tag 1: service-number */
+        if (!ASN1.decode_is_context_tag(buffer, offset + len, 1))
+            return -1;
+        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out _, out lenValueType);
+        len += ASN1.decode_unsigned(buffer, offset + len, lenValueType, out serviceNumber);
+
+        /* Tag 2: service-parameters / result-block --optional--
+         * The content is opaque (ABSTRACT-SYNTAX.&Type, "a local matter"), so it cannot be parsed;
+         * being the last element of the production its closing tag is the last octet of the APDU. */
+        if (len >= apduLen)
+            return len;
+
+        if (!ASN1.decode_is_opening_tag_number(buffer, offset + len, 2))
+            return -1;
+        len++;
+
+        var dataLen = apduLen - len - 1;
+        if (dataLen < 0 || !ASN1.decode_is_closing_tag_number(buffer, offset + apduLen - 1, 2))
+            return -1;
+
+        data = new byte[dataLen];
+        Array.Copy(buffer, offset + len, data, 0, dataLen);
+
+        return apduLen;
+    }
+
+    public static void EncodePrivateTransferError(EncodeBuffer buffer, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, uint vendorId, uint serviceNumber, byte[] data)
+    {
+        /* Tag 0: error-type */
+        EncodeError(buffer, errorClass, errorCode);
+        ASN1.encode_context_unsigned(buffer, 1, vendorId);
+        ASN1.encode_context_unsigned(buffer, 2, serviceNumber);
+
+        /* error-parameters --optional-- */
+        if (data == null || data.Length == 0)
+            return;
+
+        ASN1.encode_opening_tag(buffer, 3);
+        buffer.Add(data, data.Length);
+        ASN1.encode_closing_tag(buffer, 3);
+    }
+
+    public static int DecodePrivateTransferError(byte[] buffer, int offset, int apduLen, out BacnetErrorClasses errorClass, out BacnetErrorCodes errorCode, out uint vendorId, out uint serviceNumber, out byte[] data)
+    {
+        var len = 0;
+        uint lenValueType;
+
+        errorClass = default;
+        errorCode = default;
+        vendorId = 0;
+        serviceNumber = 0;
+        data = null;
+
+        /* Tag 0: error-type */
+        if (!ASN1.decode_is_opening_tag_number(buffer, offset + len, 0))
+            return -1;
+        var errorLen = DecodeError(buffer, offset + len, out errorClass, out errorCode);
+        if (errorLen < 0)
+            return -1;
+        len += errorLen;
+
+        /* Tag 1: vendor-id */
+        if (!ASN1.decode_is_context_tag(buffer, offset + len, 1))
+            return -1;
+        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out _, out lenValueType);
+        len += ASN1.decode_unsigned(buffer, offset + len, lenValueType, out vendorId);
+
+        /* Tag 2: service-number */
+        if (!ASN1.decode_is_context_tag(buffer, offset + len, 2))
+            return -1;
+        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out _, out lenValueType);
+        len += ASN1.decode_unsigned(buffer, offset + len, lenValueType, out serviceNumber);
+
+        /* Tag 3: error-parameters --optional-- opaque, runs to the end of the APDU (see DecodePrivateTransfer) */
+        if (len >= apduLen)
+            return len;
+
+        if (!ASN1.decode_is_opening_tag_number(buffer, offset + len, 3))
+            return -1;
+        len++;
+
+        var dataLen = apduLen - len - 1;
+        if (dataLen < 0 || !ASN1.decode_is_closing_tag_number(buffer, offset + apduLen - 1, 3))
+            return -1;
+
+        data = new byte[dataLen];
+        Array.Copy(buffer, offset + len, data, 0, dataLen);
+
+        return apduLen;
     }
 
     public static void EncodeDeviceCommunicationControl(EncodeBuffer buffer, uint timeDuration, uint enableDisable, string password)

--- a/Tests/BacnetClientPrivateTransferTests.cs
+++ b/Tests/BacnetClientPrivateTransferTests.cs
@@ -1,0 +1,136 @@
+using System.IO.BACnet.Tests.Support;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// End-to-end BacnetClient tests for the PrivateTransfer services (#154) over an in-memory
+/// transport pair: request dispatch, ack round-trip, Result(-) and the unconfirmed variant.
+/// </summary>
+public class BacnetClientPrivateTransferTests
+{
+    private static (BacnetClient client, BacnetClient server) CreateClientServerPair()
+    {
+        var (transportA, transportB) = LoopbackTransport.CreatePair();
+        var client = new BacnetClient(transportA, timeout: 500);
+        var server = new BacnetClient(transportB, timeout: 500);
+        client.Start();
+        server.Start();
+        return (client, server);
+    }
+
+    [Fact]
+    public void Confirmed_request_roundtrip_with_result_block()
+    {
+        var (client, server) = CreateClientServerPair();
+        using (client)
+        using (server)
+        {
+            uint receivedVendor = 0, receivedService = 0;
+            byte[] receivedParameters = null;
+            var receivedNeedConfirm = false;
+
+            server.OnPrivateTransfer += (sender, adr, invokeId, vendorId, serviceNumber, serviceParameters, needConfirm, maxSegments) =>
+            {
+                receivedVendor = vendorId;
+                receivedService = serviceNumber;
+                receivedParameters = serviceParameters;
+                receivedNeedConfirm = needConfirm;
+                sender.PrivateTransferResponse(adr, invokeId, null, vendorId, serviceNumber, new byte[] { 0xAA, 0xBB });
+            };
+
+            var ok = client.PrivateTransferRequest(client.Transport.GetBroadcastAddress(), 25, 8,
+                new byte[] { 0x44, 0x42, 0x90, 0xCC, 0xCD }, out var resultBlock);
+
+            Assert.True(ok);
+            Assert.Equal(25u, receivedVendor);
+            Assert.Equal(8u, receivedService);
+            Assert.Equal(new byte[] { 0x44, 0x42, 0x90, 0xCC, 0xCD }, receivedParameters);
+            Assert.True(receivedNeedConfirm);
+            Assert.Equal(new byte[] { 0xAA, 0xBB }, resultBlock);
+        }
+    }
+
+    [Fact]
+    public void Confirmed_request_roundtrip_without_result_block()
+    {
+        var (client, server) = CreateClientServerPair();
+        using (client)
+        using (server)
+        {
+            server.OnPrivateTransfer += (sender, adr, invokeId, vendorId, serviceNumber, serviceParameters, needConfirm, maxSegments) =>
+            {
+                Assert.Null(serviceParameters);
+                sender.PrivateTransferResponse(adr, invokeId, null, vendorId, serviceNumber);
+            };
+
+            var ok = client.PrivateTransferRequest(client.Transport.GetBroadcastAddress(), 25, 8, null, out var resultBlock);
+
+            Assert.True(ok);
+            Assert.Null(resultBlock);
+        }
+    }
+
+    [Fact]
+    public void Confirmed_request_error_response_throws()
+    {
+        var (client, server) = CreateClientServerPair();
+        using (client)
+        using (server)
+        {
+            server.OnPrivateTransfer += (sender, adr, invokeId, vendorId, serviceNumber, serviceParameters, needConfirm, maxSegments) =>
+            {
+                sender.PrivateTransferErrorResponse(adr, invokeId, BacnetErrorClasses.ERROR_CLASS_SERVICES,
+                    BacnetErrorCodes.ERROR_CODE_SERVICE_REQUEST_DENIED, vendorId, serviceNumber);
+            };
+
+            var ex = Assert.Throws<Exception>(() =>
+                client.PrivateTransferRequest(client.Transport.GetBroadcastAddress(), 25, 8, null, out _));
+
+            Assert.Contains("ERROR_CODE_SERVICE_REQUEST_DENIED", ex.Message);
+        }
+    }
+
+    [Fact]
+    public void Unconfirmed_request_raises_event()
+    {
+        var (client, server) = CreateClientServerPair();
+        using (client)
+        using (server)
+        {
+            uint receivedVendor = 0, receivedService = 0;
+            byte[] receivedParameters = null;
+            var receivedNeedConfirm = true;
+
+            server.OnPrivateTransfer += (sender, adr, invokeId, vendorId, serviceNumber, serviceParameters, needConfirm, maxSegments) =>
+            {
+                receivedVendor = vendorId;
+                receivedService = serviceNumber;
+                receivedParameters = serviceParameters;
+                receivedNeedConfirm = needConfirm;
+            };
+
+            client.SendUnconfirmedPrivateTransfer(client.Transport.GetBroadcastAddress(), 18, 12, new byte[] { 0x16, 0x49 });
+
+            Assert.Equal(18u, receivedVendor);
+            Assert.Equal(12u, receivedService);
+            Assert.Equal(new byte[] { 0x16, 0x49 }, receivedParameters);
+            Assert.False(receivedNeedConfirm);
+        }
+    }
+
+    [Fact]
+    public void Confirmed_request_without_handler_is_rejected()
+    {
+        var (client, server) = CreateClientServerPair();
+        using (client)
+        using (server)
+        {
+            // no OnPrivateTransfer handler on the server -> UNRECOGNIZED_SERVICE reject
+            var ex = Assert.Throws<Exception>(() =>
+                client.PrivateTransferRequest(client.Transport.GetBroadcastAddress(), 25, 8, null, out _));
+
+            Assert.Contains("Reject", ex.Message);
+        }
+    }
+}

--- a/Tests/Serialize/PrivateTransferTests.cs
+++ b/Tests/Serialize/PrivateTransferTests.cs
@@ -1,0 +1,178 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Decode and round-trip tests for the PrivateTransfer services (#154), using the golden vectors
+/// from ASHRAE 135 Annex F.4.2 / F.4.3 and the max-conveyable-APDU test message of clause 19.4.
+/// The encode direction of the Annex F vectors is covered in <see cref="AshraeAnnexFTests"/>.
+/// </summary>
+public class PrivateTransferTests
+{
+    // Annex F.4.2 service parameters: Real 72.4 followed by octet string X'1649'
+    private static readonly byte[] AnnexFServiceParameters = new byte[]
+    {
+        0x44, 0x42, 0x90, 0xCC, 0xCD, 0x62, 0x16, 0x49
+    };
+
+    [Fact] // F.4.2 - ConfirmedPrivateTransfer request
+    public void F_4_2_ConfirmedPrivateTransfer_request_decode()
+    {
+        var apdu = new byte[]
+        {
+            0x00, 0x04, 0x55, 0x12, 0x09, 0x19, 0x19, 0x08, 0x2E, 0x44, 0x42, 0x90, 0xCC, 0xCD, 0x62, 0x16, 0x49, 0x2F
+        };
+        const int headerLen = 4; // PDU type, max APDU, invoke id, service choice
+
+        var len = Services.DecodePrivateTransfer(apdu, headerLen, apdu.Length - headerLen,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(apdu.Length - headerLen, len);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Equal(AnnexFServiceParameters, data);
+    }
+
+    [Fact] // F.4.2 - ConfirmedPrivateTransfer complex-ack (no result block)
+    public void F_4_2_ConfirmedPrivateTransfer_ack_decode()
+    {
+        var apdu = new byte[] { 0x30, 0x55, 0x12, 0x09, 0x19, 0x19, 0x08 };
+        const int headerLen = 3; // PDU type, invoke id, service choice
+
+        var len = Services.DecodePrivateTransfer(apdu, headerLen, apdu.Length - headerLen,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(apdu.Length - headerLen, len);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Null(data);
+    }
+
+    [Fact] // F.4.3 - UnconfirmedPrivateTransfer request
+    public void F_4_3_UnconfirmedPrivateTransfer_request_decode()
+    {
+        var apdu = new byte[]
+        {
+            0x10, 0x04, 0x09, 0x19, 0x19, 0x08, 0x2E, 0x44, 0x42, 0x90, 0xCC, 0xCD, 0x62, 0x16, 0x49, 0x2F
+        };
+        const int headerLen = 2; // PDU type, service choice
+
+        var len = Services.DecodePrivateTransfer(apdu, headerLen, apdu.Length - headerLen,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(apdu.Length - headerLen, len);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Equal(AnnexFServiceParameters, data);
+    }
+
+    [Fact] // 19.4.2 - the ASHRAE max conveyable APDU test message (vendor 0, service 0, 1462-octet payload)
+    public void Clause_19_4_2_max_conveyable_apdu_test_message()
+    {
+        var parameters = new EncodeBuffer();
+        ASN1.encode_application_octet_string(parameters, new byte[1462], 0, 1462);
+
+        var buffer = new EncodeBuffer();
+        Services.EncodePrivateTransferConfirmed(buffer, 0, 0, parameters.ToArray());
+        var encoded = buffer.ToArray();
+
+        // 19.4.2: SD context tags 0 and 1 with value 0, then the octet string with extended length 1462
+        Assert.Equal(new byte[] { 0x09, 0x00, 0x19, 0x00, 0x2E, 0x65, 0xFE, 0x05, 0xB6 }, encoded[..9]);
+        Assert.Equal(0x2F, encoded[^1]);
+
+        var len = Services.DecodePrivateTransfer(encoded, 0, encoded.Length,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(0u, vendorId);
+        Assert.Equal(0u, serviceNumber);
+        Assert.Equal(parameters.ToArray(), data);
+    }
+
+    [Fact] // service-parameters is OPTIONAL - absent must encode without the [2] tags and decode to null
+    public void Request_without_parameters_roundtrip()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodePrivateTransferConfirmed(buffer, 25, 8, null);
+        var encoded = buffer.ToArray();
+
+        Assert.Equal(new byte[] { 0x09, 0x19, 0x19, 0x08 }, encoded);
+
+        var len = Services.DecodePrivateTransfer(encoded, 0, encoded.Length,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Null(data);
+    }
+
+    [Fact] // vendor-id is Unsigned16 and service-number Unsigned - exercise multi-octet values
+    public void Large_vendor_and_service_number_roundtrip()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodePrivateTransferConfirmed(buffer, 65535, 305419896, new byte[] { 0x01 });
+        var encoded = buffer.ToArray();
+
+        var len = Services.DecodePrivateTransfer(encoded, 0, encoded.Length,
+            out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(65535u, vendorId);
+        Assert.Equal(305419896u, serviceNumber);
+        Assert.Equal(new byte[] { 0x01 }, data);
+    }
+
+    [Fact]
+    public void Truncated_or_malformed_request_is_rejected()
+    {
+        // missing closing tag 2
+        Assert.Equal(-1, Services.DecodePrivateTransfer(new byte[] { 0x09, 0x19, 0x19, 0x08, 0x2E, 0x44 }, 0, 6, out _, out _, out _));
+        // wrong leading tag
+        Assert.Equal(-1, Services.DecodePrivateTransfer(new byte[] { 0x19, 0x19, 0x09, 0x08 }, 0, 4, out _, out _, out _));
+    }
+
+    [Fact] // ConfirmedPrivateTransfer-Error: error-type [0], vendor-id [1], service-number [2], error-parameters [3]
+    public void PrivateTransferError_roundtrip()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodePrivateTransferError(buffer, BacnetErrorClasses.ERROR_CLASS_SERVICES,
+            BacnetErrorCodes.ERROR_CODE_SERVICE_REQUEST_DENIED, 25, 8, new byte[] { 0x21, 0x07 });
+        var encoded = buffer.ToArray();
+
+        var len = Services.DecodePrivateTransferError(encoded, 0, encoded.Length,
+            out var errorClass, out var errorCode, out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(BacnetErrorClasses.ERROR_CLASS_SERVICES, errorClass);
+        Assert.Equal(BacnetErrorCodes.ERROR_CODE_SERVICE_REQUEST_DENIED, errorCode);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Equal(new byte[] { 0x21, 0x07 }, data);
+
+        // the generic Error decoder used by ProcessError must still extract the error-type from it
+        Assert.True(Services.DecodeError(encoded, 0, out var genericClass, out var genericCode) > 0);
+        Assert.Equal(BacnetErrorClasses.ERROR_CLASS_SERVICES, genericClass);
+        Assert.Equal(BacnetErrorCodes.ERROR_CODE_SERVICE_REQUEST_DENIED, genericCode);
+    }
+
+    [Fact]
+    public void PrivateTransferError_without_parameters_roundtrip()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodePrivateTransferError(buffer, BacnetErrorClasses.ERROR_CLASS_DEVICE,
+            BacnetErrorCodes.ERROR_CODE_OTHER, 25, 8, null);
+        var encoded = buffer.ToArray();
+
+        var len = Services.DecodePrivateTransferError(encoded, 0, encoded.Length,
+            out var errorClass, out var errorCode, out var vendorId, out var serviceNumber, out var data);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(BacnetErrorClasses.ERROR_CLASS_DEVICE, errorClass);
+        Assert.Equal(BacnetErrorCodes.ERROR_CODE_OTHER, errorCode);
+        Assert.Equal(25u, vendorId);
+        Assert.Equal(8u, serviceNumber);
+        Assert.Null(data);
+    }
+}

--- a/Tests/Support/LoopbackTransport.cs
+++ b/Tests/Support/LoopbackTransport.cs
@@ -1,0 +1,47 @@
+namespace System.IO.BACnet.Tests.Support;
+
+/// <summary>
+/// In-memory transport wiring two <see cref="BacnetClient"/> instances directly to each other:
+/// frames handed to <see cref="Send"/> are delivered synchronously to the peer's MessageRecieved.
+/// </summary>
+internal class LoopbackTransport : IBacnetTransport
+{
+    private LoopbackTransport _peer;
+
+    public byte MaxInfoFrames { get; set; } = 0xFF;
+    public int HeaderLength => 0;
+    public int MaxBufferLength => 1500;
+    public BacnetAddressTypes Type => BacnetAddressTypes.None;
+    public BacnetMaxAdpu MaxAdpuLength => BacnetMaxAdpu.MAX_APDU1476;
+
+    public event MessageRecievedHandler MessageRecieved;
+
+    public static (LoopbackTransport, LoopbackTransport) CreatePair()
+    {
+        var a = new LoopbackTransport();
+        var b = new LoopbackTransport();
+        a._peer = b;
+        b._peer = a;
+        return (a, b);
+    }
+
+    public void Start()
+    {
+    }
+
+    public BacnetAddress GetBroadcastAddress() => new BacnetAddress(BacnetAddressTypes.None, 0, null);
+
+    public bool WaitForAllTransmits(int timeout) => true;
+
+    public int Send(byte[] buffer, int offset, int dataLength, BacnetAddress address, bool waitForTransmission, int timeout)
+    {
+        var frame = new byte[dataLength];
+        Array.Copy(buffer, offset, frame, 0, dataLength);
+        _peer.MessageRecieved?.Invoke(_peer, frame, 0, dataLength, new BacnetAddress(BacnetAddressTypes.None, 0, null));
+        return dataLength;
+    }
+
+    public void Dispose()
+    {
+    }
+}


### PR DESCRIPTION
Adds send/receive support for the PrivateTransfer services to BacnetClient. The library already had the encoders but no decoders, client methods, or events, so proprietary services could not be invoked or served.

- OnPrivateTransfer event (confirmed + unconfirmed)
- PrivateTransferRequest / Begin / End; SendUnconfirmedPrivateTransfer
- PrivateTransferResponse and PrivateTransferErrorResponse (Result(-))
- DecodePrivateTransfer, Encode/DecodePrivateTransferError

Tested with 14 unit tests using the ASHRAE 135 Annex F.4.2/F.4.3 golden vectors and the clause 19.4.2 max-conveyable-APDU message, plus an in-memory client<->server round-trip. Also validated end-to-end against bacnet-stack 1.5.0 (C) over Docker, both directions.

Closes #154