### PR TITLE
fix: clear error and docs when System.IO.Ports native lib is missing

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,6 +92,21 @@ The `(portName, baudRate, …)` convenience constructors on `BacnetMstpProtocolT
 The core still contains the MS/TP and PTP protocol logic and the `IBacnetSerialTransport` abstraction;
 only the physical `SerialPort` implementation moved.
 
+### Publishing `BACnet.Serial` for Linux / Raspberry Pi
+
+On the modern targets (`net8.0`/`net10.0`), `BACnet.Serial` pulls the `System.IO.Ports` package, which
+ships a platform-specific native library alongside its managed assembly. When you publish for a
+non-Windows target — a Raspberry Pi being the common case — that native library is only deployed if the
+publish knows which platform it targets. Publish with an explicit Runtime Identifier so it is included:
+
+```sh
+dotnet publish --runtime linux-arm64   # 64-bit Raspberry Pi OS
+dotnet publish --runtime linux-arm     # 32-bit Raspberry Pi OS
+```
+
+Without a Runtime Identifier (most often with `--self-contained` or single-file publishes) the native
+part is missing and opening a port throws at runtime.
+
 ## Network interface must be explicit when a host has multiple interfaces
 
 In 3.x, `BacnetIpUdpProtocolTransport` silently picked a network interface for you when the machine

--- a/Serial/BacnetSerialPortTransport.cs
+++ b/Serial/BacnetSerialPortTransport.cs
@@ -3,14 +3,18 @@ namespace System.IO.BACnet;
 public class BacnetSerialPortTransport : IBacnetSerialTransport
 {
     private readonly string _portName;
-    private readonly SerialPort _port;
+    private readonly int _baudRate;
+    private SerialPort _port;
 
     public int BytesToRead => _port?.BytesToRead ?? 0;
 
     public BacnetSerialPortTransport(string portName, int baudRate)
     {
+        // Deliberately does not touch SerialPort here: on runtimes where System.IO.Ports is a
+        // package (net8/net10) merely referencing the type triggers the assembly/native load, and
+        // we want that to fail inside Open() where it can be reported with actionable guidance.
         _portName = portName;
-        _port = new SerialPort(_portName, baudRate, Parity.None, 8, StopBits.One);
+        _baudRate = baudRate;
     }
 
     public override bool Equals(object obj)
@@ -32,7 +36,47 @@ public class BacnetSerialPortTransport : IBacnetSerialTransport
 
     public void Open()
     {
+        // OpenCore is a separate method on purpose: if the System.IO.Ports managed assembly is
+        // missing, the JIT-time load failure is thrown at the call site (here), so a try/catch
+        // inside OpenCore itself would never see it. Wrapping the call does.
+        try
+        {
+            OpenCore();
+        }
+        catch (Exception ex) when (IsMissingSerialSupport(ex))
+        {
+            throw new PlatformNotSupportedException(
+                $"Failed to load native serial-port support while opening '{_portName}'. The " +
+                "System.IO.Ports native library was not deployed with the application. Publish with " +
+                "an explicit Runtime Identifier so the native serial library is included, for example " +
+                "'dotnet publish --runtime linux-arm64' on a 64-bit Raspberry Pi (or " +
+                "'--runtime linux-arm' for a 32-bit OS).",
+                ex);
+        }
+    }
+
+    private void OpenCore()
+    {
+        _port ??= new SerialPort(_portName, _baudRate, Parity.None, 8, StopBits.One);
         _port.Open();
+    }
+
+    // True when the exception chain indicates System.IO.Ports could not be loaded — either the
+    // managed assembly (FileNotFound/FileLoad/TypeInitialization referencing it) or the native
+    // library (DllNotFound). Distinguishes a missing-deployment problem from an in-use/access error.
+    private static bool IsMissingSerialSupport(Exception ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e is DllNotFoundException)
+                return true;
+
+            if ((e is FileNotFoundException || e is FileLoadException || e is TypeInitializationException)
+                && e.Message?.IndexOf("System.IO.Ports", StringComparison.OrdinalIgnoreCase) >= 0)
+                return true;
+        }
+
+        return false;
     }
 
     public void Write(byte[] buffer, int offset, int length)


### PR DESCRIPTION
## Problem

Publishing a `BACnet.Serial` consumer for a non-Windows target — a Raspberry Pi (Linux/ARM) being the common case — without an explicit Runtime Identifier omits the `System.IO.Ports` native library. Opening a port then failed at runtime with a bare `FileNotFoundException` that gave no hint at the cause, sending people on a debugging hunt.

Related to #157.

## Changes

- **`BacnetSerialPortTransport`** now constructs the `SerialPort` lazily and opens it through a wrapped `OpenCore()`. That split is load-bearing: a missing *managed* `System.IO.Ports` assembly surfaces as a JIT-time load failure thrown at the *call site*, so a `try` inside the method touching `SerialPort` would never catch it — wrapping the call does. It also catches the missing *native* library (`DllNotFoundException` from `Open()`). On either, it rethrows a `PlatformNotSupportedException` explaining that the app must be published with an explicit Runtime Identifier (e.g. `dotnet publish --runtime linux-arm64`). Genuine port-in-use / access errors pass through unchanged.
- **`MIGRATION.md`** gains a "Publishing `BACnet.Serial` for Linux / Raspberry Pi" subsection with the `--runtime linux-arm64` / `linux-arm` commands.

## Notes

The Runtime Identifier is inherently a deploy-time choice the consuming app makes, so a library package cannot select it automatically without breaking other platforms. This PR therefore improves discoverability at both layers — the guide before build, and a clear runtime message after.

Builds clean across `net48`/`net8.0`/`net10.0`.
@
