### PR TITLE
fix: encode the Error PDU without spurious context tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - OS detection in the UDP transport now uses `RuntimeInformation.IsOSPlatform`, fixing `DontFragment` on
   macOS (#91) and making the Windows-only `SIO_UDP_CONNRESET` guard analyzer-clean.
 - Response correlation matches by invoke-id per ASHRAE 135 §20.1.2.6 (#141, #149).
+- `ErrorResponse` sends the Error PDU with the plain §20.1.7 encoding again: since 3.x the error
+  class/code pair was wrapped in spurious context tags, so foreign stacks mis-decoded every error this
+  library returned (the tolerant decoder hid it from same-stack round-trips) (#199). Context wrapping
+  is now explicit at the call sites whose ASN.1 requires it (private-transfer error-type `[0]`,
+  trend-log failure log-datum `[8]`).
 - Multi-object `WritePropertyMultiple` decoding (#158), DATE/TIME/DATETIME culture-invariant
   serialization (#159), float/double property serialization (#143), and several encoder fixes surfaced
   by the Annex F vectors (wildcard time, private-transfer ack, log-record status flags).

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -1512,7 +1512,7 @@ public class Services
     public static void EncodePrivateTransferError(EncodeBuffer buffer, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, uint vendorId, uint serviceNumber, byte[] data)
     {
         /* Tag 0: error-type */
-        EncodeError(buffer, errorClass, errorCode);
+        EncodeError(buffer, errorClass, errorCode, 0);
         ASN1.encode_context_unsigned(buffer, 1, vendorId);
         ASN1.encode_context_unsigned(buffer, 2, serviceNumber);
 
@@ -2550,12 +2550,22 @@ public class Services
         return len;
     }
 
-    public static void EncodeError(EncodeBuffer buffer, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, byte tagNumber = 0)
+    /// <summary>
+    /// Encode the 'Error' production (ASHRAE 135 clause 21): error-class and
+    /// error-code as two application-tagged enumerations. The plain form is
+    /// what the BACnet-Error-PDU carries (clause 20.1.7). Pass
+    /// <paramref name="tagNumber"/> only where a service's ASN.1 wraps the
+    /// Error in a context tag, e.g. ConfirmedPrivateTransfer-Error
+    /// 'error-type' [0] or the trend-log 'failure' log-datum [8].
+    /// </summary>
+    public static void EncodeError(EncodeBuffer buffer, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, byte? tagNumber = null)
     {
-        ASN1.encode_opening_tag(buffer, tagNumber);
+        if (tagNumber.HasValue)
+            ASN1.encode_opening_tag(buffer, tagNumber.Value);
         ASN1.encode_application_enumerated(buffer, (uint)errorClass);
         ASN1.encode_application_enumerated(buffer, (uint)errorCode);
-        ASN1.encode_closing_tag(buffer, tagNumber);
+        if (tagNumber.HasValue)
+            ASN1.encode_closing_tag(buffer, tagNumber.Value);
     }
 
     public static int DecodeError(byte[] buffer, int offset, out BacnetErrorClasses errorClass, out BacnetErrorCodes errorCode)

--- a/Tests/Serialize/ErrorPduTests.cs
+++ b/Tests/Serialize/ErrorPduTests.cs
@@ -1,0 +1,64 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// The Error PDU carries the plain 'Error' production - two application-tagged
+/// enumerations with no enclosing context tags (ASHRAE 135 §20.1.7). Since 3.x
+/// the encoder wrapped them in context tags (#199), which foreign stacks
+/// mis-decode; the tolerant decoder hid it from same-stack round-trips, so
+/// these tests assert the raw wire bytes.
+/// </summary>
+public class ErrorPduTests
+{
+    [Fact]
+    public void Plain_error_encoding_matches_the_error_pdu_production()
+    {
+        var buffer = new EncodeBuffer();
+
+        Services.EncodeError(buffer, BacnetErrorClasses.ERROR_CLASS_OBJECT,
+            BacnetErrorCodes.ERROR_CODE_UNKNOWN_OBJECT);
+
+        // enumerated 1 (object), enumerated 31 (unknown-object) - nothing else
+        Assert.Equal(new byte[] { 0x91, 0x01, 0x91, 0x1F }, buffer.ToArray());
+    }
+
+    [Fact]
+    public void Full_error_pdu_bytes_for_read_property_unknown_object()
+    {
+        var buffer = new EncodeBuffer();
+
+        APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY, 7);
+        Services.EncodeError(buffer, BacnetErrorClasses.ERROR_CLASS_OBJECT,
+            BacnetErrorCodes.ERROR_CODE_UNKNOWN_OBJECT);
+
+        // [pdu-type][invoke-id][error-choice] class code (135 §20.1.7)
+        Assert.Equal(new byte[] { 0x50, 0x07, 0x0C, 0x91, 0x01, 0x91, 0x1F }, buffer.ToArray());
+    }
+
+    [Fact]
+    public void Explicit_tag_wraps_for_context_tagged_error_productions()
+    {
+        var buffer = new EncodeBuffer();
+
+        // e.g. the trend-log 'failure' log-datum is a [8]-wrapped Error
+        Services.EncodeError(buffer, BacnetErrorClasses.ERROR_CLASS_PROPERTY,
+            BacnetErrorCodes.ERROR_CODE_UNKNOWN_PROPERTY, 8);
+
+        Assert.Equal(new byte[] { 0x8E, 0x91, 0x02, 0x91, 0x20, 0x8F }, buffer.ToArray());
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 0x91, 0x01, 0x91, 0x1F })]             // plain (spec)
+    [InlineData(new byte[] { 0x0E, 0x91, 0x01, 0x91, 0x1F, 0x0F })] // legacy 3.x wrapped
+    public void DecodeError_accepts_plain_and_legacy_wrapped_forms(byte[] encoded)
+    {
+        var len = Services.DecodeError(encoded, 0, out var errorClass, out var errorCode);
+
+        Assert.Equal(encoded.Length, len);
+        Assert.Equal(BacnetErrorClasses.ERROR_CLASS_OBJECT, errorClass);
+        Assert.Equal(BacnetErrorCodes.ERROR_CODE_UNKNOWN_OBJECT, errorCode);
+    }
+}


### PR DESCRIPTION
Fixes the malformed Error PDU described in #199: since 3.x, `Services.EncodeError` wrapped the error class/code pair in context tags by default, so every error sent by `ErrorResponse` violated ASHRAE 135 §20.1.7 (the BACnet-Error-PDU carries the plain `Error` production — two application-tagged enumerations, no enclosing context tags). Foreign stacks mis-decoded every error this library returned; the tolerant `DecodeError` hid it from C#↔C# round-trips. 2.0.4 was correct — the regression came in with 2f23aba, whose tag-wrapping is genuinely needed only for the trend-log `failure` log-datum.

## Changes

- `Services.EncodeError`: `tagNumber` is now nullable and **opt-in** — plain encoding by default.
- The two call sites whose ASN.1 actually wraps the `Error` pass their tags explicitly: `EncodePrivateTransferError` (`error-type [0]`) and `EncodeLogRecord` (`failure` log-datum `[8]`). `ErrorResponse` gets the plain encoding without a call-site change.
- `DecodeError` stays tolerant (accepts both plain and legacy-wrapped forms), so errors from peers running affected 3.x/4.0-beta versions still decode.
- Regression tests assert **raw wire bytes** — deliberately not round-tripping through the tolerant decoder, which is exactly how this went unnoticed.

## Verification

- Unit: 142/142 (5 new in `ErrorPduTests`: plain production bytes, full Error-PDU bytes, explicit-tag wrapping, plain+legacy decode).
- Container interop (bacnet-stack 1.5.0 client → bacnet-stack router → this library as device, same lab as #198):

| Test (stock `bacrp` via router) | 4.0.0-beta.1 / master | this branch |
|---|---|---|
| read `analog-value 999` (unknown object) | `BACnet Error: services: success` | `BACnet Error: object: unknown-object` |
| read unknown property on device object | `BACnet Error: services: success` | `BACnet Error: property: unknown-property` |
| normal read sanity | ✅ | ✅ unchanged |

Independent of #198 (no shared files apart from a trivial CHANGELOG adjacency).

Closes #199.
