### PR TITLE
fix: create the GitHub Release without pwsh array splatting into gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # note: no array splatting into the native gh call - pwsh mangles it
+          # (a stray '-' token made `gh release create` fail on v4.0.0-beta.2)
           $tag = '${{ github.ref_name }}'
-          $flags = if ($tag -match '-') { @('--prerelease') } else { @() }
-          gh release create $tag --title $tag --generate-notes @flags
+          if ($tag -match '-') {
+            gh release create $tag --title $tag --generate-notes --prerelease
+          } else {
+            gh release create $tag --title $tag --generate-notes
+          }


### PR DESCRIPTION
The `Create GitHub Release` step failed on the [v4.0.0-beta.2 tag run](https://github.com/ela-compil/BACnet/actions/runs/28719475982) with ``no matches found for `-` `` while all four packages published fine. Root cause: splatting the `$flags` array into the native `gh` invocation — pwsh mangles the arguments. Reproduced locally: the splatted form fails with the same error, the identical command with literal flags succeeds (that manual invocation is what created the [beta.2 release](https://github.com/ela-compil/BACnet/releases/tag/v4.0.0-beta.2)).

Fix: explicit if/else with literal flags, no array building. Behavior is unchanged — prerelease-suffixed tags (`-beta.*`, `-rc.*`) get `--prerelease`, stable tags do not.

Verified: the prerelease branch of the script is the exact literal command that succeeded locally (it created the actual beta.2 release); the stable branch is the same invocation minus `--prerelease`. The next tag exercises the step for real.
