### PR TITLE
Improve the produced NuGet packages: ship XML docs + package validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,11 @@ jobs:
     - name: Build examples (Windows)
       if: runner.os == 'Windows'
       run: dotnet build Examples/BACnet.Examples.slnx -c Release
+    # Pack on Windows (all target frameworks are present there) so EnablePackageValidation runs its
+    # cross-TFM compatibility checks on every PR, not only on a release tag.
+    - name: Pack (packaging + validation smoke test, Windows)
+      if: runner.os == 'Windows'
+      run: dotnet pack --no-build -c Release -o artifacts
     - name: Build (Linux - netstandard2.0)
       if: runner.os == 'Linux'
       run: dotnet build BACnet.csproj --no-restore -c Release -f netstandard2.0

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,6 +36,12 @@
          not every local build. -->
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 
+    <!-- Package validation: run the SDK's compatibility checks at pack time. This catches missing
+         target-framework assets and any accidental public-API break across the multi-targeted
+         surface (net48/netstandard2.0/net8.0/net10.0). Baseline-against-a-previous-release checks
+         stay off until a stable v4 ships on nuget.org - set PackageValidationBaselineVersion then. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+
     <!-- Versioning is tag-driven via MinVer: the git tag IS the package/file version. Release tags
          are v-prefixed (e.g. v4.0.0); MinimumMajorMinor floors untagged builds at 4.0.0-alpha.0.<height>
          until the first v4 tag. AssemblyVersion stays pinned major-only so net48 consumers avoid

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,12 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
 
+    <!-- Ship the XML documentation file inside every package so consumers get IntelliSense tooltips
+         for the doc-commented public API. CS1591 is silenced because the API is only partially
+         documented today; without this the existing /// comments never reach consumers at all. -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
     <!-- Organisation-wide package metadata -->
     <Company>Ela-compil sp. z o.o.</Company>
     <Authors>Morten Kvistgaard, F. Chaxel, Ela-compil sp. z o.o. and contributors</Authors>


### PR DESCRIPTION
Two packaging improvements.

**Ship XML documentation.** The core has ~305 `///` comments but no project set `GenerateDocumentationFile`, so the docs were never emitted or packed — consumers got no IntelliSense. Enabled it in `Directory.Build.props`; `dotnet pack` now bundles the `.xml` next to each assembly. `CS1591` is silenced (the API is only partially documented).

**Package validation.** Enabled `EnablePackageValidation` so the SDK checks for missing target-framework assets and public-API breaks across `net48`/`netstandard2.0`/`net8.0`/`net10.0` at pack time. Baseline validation stays off until a stable v4 is on nuget.org. Only the release-on-tag workflow packed before, so added a Windows pack step to `build.yml` (all TFMs build there) to exercise validation on every PR.

Packaging + CI only, no runtime changes.