### PR TITLE
fix: address peers behind a BACnet router in all unconfirmed sends

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1145,20 +1145,25 @@ public class BacnetClient : IDisposable
 
     public void WhoIs(int lowLimit = -1, int highLimit = -1, BacnetAddress receiver = null, BacnetAddress source = null)
     {
+        BacnetAddress npduDestination;
         if (receiver == null)
         {
-            // _receiver could be an unicast @ : for direct acces 
+            // _receiver could be an unicast @ : for direct acces
             // usefull on BIP for a known IP:Port, unknown device Id
             receiver = Transport.GetBroadcastAddress();
+            npduDestination = receiver;
             Log.LogDebug("Broadcasting WhoIs");
         }
         else
         {
-            Log.LogDebug($"Sending WhoIs to {receiver}");
+            // a receiver behind a BACnet router: address the NPDU to its
+            // network/MAC while the frame goes to the router that fronts it
+            npduDestination = receiver.RoutedSource ?? receiver;
+            Log.LogDebug($"Sending WhoIs to {receiver.ToString(false)}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, receiver, source);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, npduDestination, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_WHO_IS);
         Services.EncodeWhoIsBroadcast(b, lowLimit, highLimit);
 
@@ -1204,18 +1209,23 @@ public class BacnetClient : IDisposable
 
     private void WhoHasCore(BacnetObjectId? objId, string objName, int lowLimit, int highLimit, BacnetAddress receiver, BacnetAddress source)
     {
+        BacnetAddress npduDestination;
         if (receiver == null)
         {
             receiver = Transport.GetBroadcastAddress();
+            npduDestination = receiver;
             Log.LogDebug($"Broadcasting WhoHas {objId?.ToString() ?? objName}");
         }
         else
         {
-            Log.LogDebug($"Sending WhoHas {objId?.ToString() ?? objName} to {receiver}");
+            // a receiver behind a BACnet router: address the NPDU to its
+            // network/MAC while the frame goes to the router that fronts it
+            npduDestination = receiver.RoutedSource ?? receiver;
+            Log.LogDebug($"Sending WhoHas {objId?.ToString() ?? objName} to {receiver.ToString(false)}");
         }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, receiver, source);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, npduDestination, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_WHO_HAS);
         Services.EncodeWhoHasBroadcast(b, lowLimit, highLimit, objId, objName);
 
@@ -1223,17 +1233,33 @@ public class BacnetClient : IDisposable
     }
 
     // ReSharper disable once InconsistentNaming
-    public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source = null)
+    // note: receiver comes after source (unlike Iam/WhoIs/WhoHas) so that
+    // pre-4.0 positional `source` callers keep compiling with the same
+    // meaning; harmonize the order in 5.0 alongside the namespace rename
+    public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source = null, BacnetAddress receiver = null)
     {
-        Log.LogDebug($"Broadcasting IHave {objName} {objId}");
+        BacnetAddress npduDestination;
+        if (receiver == null)
+        {
+            receiver = Transport.GetBroadcastAddress();
+            npduDestination = receiver;
+            Log.LogDebug($"Broadcasting IHave {objName} {objId}");
+        }
+        else
+        {
+            // answering a Who-Has that came through a BACnet router: the NPDU
+            // destination is the original source network/address while the
+            // frame goes back to the router that forwarded it (135 §16.9)
+            npduDestination = receiver.RoutedSource ?? receiver;
+            Log.LogDebug($"Sending IHave {objName} {objId} to {receiver.ToString(false)}");
+        }
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        var broadcast = Transport.GetBroadcastAddress();
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, broadcast, source);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, npduDestination, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_I_HAVE);
         Services.EncodeIhaveBroadcast(b, deviceId, objId, objName);
 
-        Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, broadcast, false, 0);
+        Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, receiver, false, 0);
     }
 
     public void SendUnconfirmedEventNotification(BacnetAddress adr, BacnetEventNotificationData eventData, BacnetAddress source = null)
@@ -1241,7 +1267,9 @@ public class BacnetClient : IDisposable
         Log.LogDebug($"Sending Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
+        // adr.RoutedSource: peers behind a BACnet router get the NPDU addressed
+        // to their network/MAC while the frame goes to the fronting router
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource ?? adr, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_EVENT_NOTIFICATION);
         Services.EncodeEventNotifyUnconfirmed(b, eventData);
         Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
@@ -1252,7 +1280,7 @@ public class BacnetClient : IDisposable
         Log.LogDebug($"Sending UnconfirmedPrivateTransfer vendor {vendorId} service {serviceNumber}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr, source);
+        NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource ?? adr, source);
         APDU.EncodeUnconfirmedServiceRequest(b, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_PRIVATE_TRANSFER);
         Services.EncodePrivateTransferUnconfirmed(b, vendorId, serviceNumber, serviceParameters);
         Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
@@ -1286,7 +1314,7 @@ public class BacnetClient : IDisposable
         Log.LogDebug($"Sending Time Synchronize: {dateTime} {dateTime.Kind.ToString().ToUpper()}");
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
-        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr, source);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource ?? adr, source);
         APDU.EncodeUnconfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_UNCONFIRMED_SERVICE_REQUEST, dateTime.Kind == DateTimeKind.Utc
                 ? BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_UTC_TIME_SYNCHRONIZATION
                 : BacnetUnconfirmedServices.SERVICE_UNCONFIRMED_TIME_SYNCHRONIZATION);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - OS detection in the UDP transport now uses `RuntimeInformation.IsOSPlatform`, fixing `DontFragment` on
   macOS (#91) and making the Windows-only `SIO_UDP_CONNRESET` guard analyzer-clean.
 - Response correlation matches by invoke-id per ASHRAE 135 §20.1.2.6 (#141, #149).
+- All unconfirmed sends now address peers behind a BACnet router correctly (NPDU destination =
+  the peer's network/MAC, frame to the fronting router — the same addressing the `Iam()` fix
+  established): directed `WhoIs`/`WhoHas`, `SendUnconfirmedEventNotification`,
+  `SendUnconfirmedPrivateTransfer` and `SynchronizeTime`. `IHave()` gained an optional `receiver`
+  parameter (appended after `source` to stay source-compatible) so it can answer a Who-Has that
+  arrived through a router (135 §16.9).
 - `ErrorResponse` sends the Error PDU with the plain §20.1.7 encoding again: since 3.x the error
   class/code pair was wrapped in spurious context tags, so foreign stacks mis-decoded every error this
   library returned (the tolerant decoder hid it from same-stack round-trips) (#199). Context wrapping

--- a/Tests/BacnetClientRoutedSendsTests.cs
+++ b/Tests/BacnetClientRoutedSendsTests.cs
@@ -1,0 +1,128 @@
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Unconfirmed sends to a peer behind a BACnet router: the NPDU destination
+/// must be the peer's network/MAC (RoutedSource) while the datalink frame goes
+/// to the fronting router - the same addressing the Iam fix established.
+/// </summary>
+public class BacnetClientRoutedSendsTests
+{
+    private static readonly byte[] PeerMac = { 172, 28, 1, 20, 0xBA, 0xC0 };
+
+    private static (BacnetClient client, RecordingTransport transport, BacnetAddress router) Setup()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        client.Start();
+
+        var router = new BacnetAddress(BacnetAddressTypes.IP, "172.28.2.10:47808")
+        {
+            RoutedSource = new BacnetAddress(BacnetAddressTypes.None, 1, PeerMac)
+        };
+        return (client, transport, router);
+    }
+
+    private static void AssertRoutedFrame(RecordingTransport transport, BacnetAddress router)
+    {
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Same(router, sentTo); // datalink frame goes to the router
+
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.NotNull(destination); // NPDU carries DNET/DADR of the peer
+        Assert.Equal((ushort)1, destination.net);
+        Assert.Equal(PeerMac, destination.adr);
+    }
+
+    [Fact]
+    public void WhoIs_to_routed_receiver_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        client.WhoIs(1234, 1234, router);
+        AssertRoutedFrame(transport, router);
+    }
+
+    [Fact]
+    public void WhoIs_without_receiver_broadcasts_locally()
+    {
+        var (client, transport, _) = Setup();
+        client.WhoIs();
+
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Equal(transport.GetBroadcastAddress(), sentTo);
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.Null(destination);
+    }
+
+    [Fact]
+    public void WhoHas_to_routed_receiver_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        client.WhoHas("Room temperature", receiver: router);
+        AssertRoutedFrame(transport, router);
+    }
+
+    [Fact]
+    public void IHave_to_routed_receiver_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        client.IHave(new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 1234),
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), "Room temperature", receiver: router);
+        AssertRoutedFrame(transport, router);
+    }
+
+    [Fact]
+    public void IHave_without_receiver_broadcasts_locally()
+    {
+        var (client, transport, _) = Setup();
+        client.IHave(new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 1234),
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), "Room temperature");
+
+        var (frame, sentTo) = Assert.Single(transport.Sent);
+        Assert.Equal(transport.GetBroadcastAddress(), sentTo);
+        NPDU.Decode(frame, 0, out _, out var destination, out _, out _, out _, out _);
+        Assert.Null(destination);
+    }
+
+    [Fact]
+    public void SynchronizeTime_to_routed_peer_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        client.SynchronizeTime(router, new DateTime(2026, 7, 5, 12, 0, 0, DateTimeKind.Local));
+        AssertRoutedFrame(transport, router);
+    }
+
+    [Fact]
+    public void UnconfirmedPrivateTransfer_to_routed_peer_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        client.SendUnconfirmedPrivateTransfer(router, 260, 1, new byte[] { 1, 2, 3 });
+        AssertRoutedFrame(transport, router);
+    }
+
+    [Fact]
+    public void UnconfirmedEventNotification_to_routed_peer_targets_peer_via_router()
+    {
+        var (client, transport, router) = Setup();
+        var eventData = new BacnetEventNotificationData
+        {
+            processIdentifier = 1,
+            initiatingObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 1234),
+            eventObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1),
+            timeStamp = new BacnetGenericTime(DateTime.Now, BacnetTimestampTags.TIME_STAMP_DATETIME),
+            notificationClass = 1,
+            priority = 1,
+            // ack-notification carries no event-values production, which keeps
+            // this test focused on the NPDU addressing
+            notifyType = BacnetNotifyTypes.NOTIFY_ACK_NOTIFICATION,
+            fromState = BacnetEventStates.EVENT_STATE_NORMAL,
+            toState = BacnetEventStates.EVENT_STATE_NORMAL
+        };
+
+        client.SendUnconfirmedEventNotification(router, eventData);
+        AssertRoutedFrame(transport, router);
+    }
+}


### PR DESCRIPTION
Completes the routed-services theme from #198: the remaining unconfirmed senders encoded the receiver address directly as the NPDU destination, so sends to a peer behind a BACnet router were delivered to the router with no routing information and died there — the same mis-addressing `Iam()` had before #198.

## Changes

All unconfirmed sends now use the addressing #198 established (NPDU destination = the peer's network/MAC from `RoutedSource`, datalink frame to the fronting router):

| Method | Notes |
|---|---|
| `WhoIs` / `WhoHas` (directed) | broadcast paths byte-identical to before |
| `SendUnconfirmedEventNotification` | routed COV/alarm recipients never worked — present since 2.0.4 (verified against the tag) |
| `SendUnconfirmedPrivateTransfer` | new in #200; caught before it ships in a stable release |
| `SynchronizeTime` | present since 2.0.4 |
| `IHave` | gains an optional `receiver` parameter so it can answer a Who-Has that arrived through a router (ASHRAE 135 §16.9) |

`SendConfirmedServiceReject` and `SendAbort` were audited and already correct (`RoutedSource`/`RoutedDestination` since 2.0.4).

## Compatibility

No breaking changes. `IHave`'s new `receiver` is **appended after** the existing `source` parameter, so positional callers keep compiling with unchanged meaning; routed replies pass it by name (`receiver: adr`). A true overload was rejected because two overloads whose fourth `BacnetAddress` parameter means different things resolve silently by arity — a trap, not an API. A code comment earmarks harmonizing the parameter order with `Iam`/`WhoIs`/`WhoHas` for 5.0, where the planned namespace rename already forces callers to touch code.

## Verification

- 158/158 unit tests; 8 new in `BacnetClientRoutedSendsTests` (RecordingTransport, NPDU byte assertions) covering each sender's routed path plus the unchanged broadcast paths.
- The wire pattern is identical to the `Iam()` fix, which was verified end-to-end through a real bacnet-stack router in the container interop lab (#198) and matches bacnet-stack's BTL-tested `Send_I_Am_Unicast` ("must direct back to src->net to meet BTL tests").
