### PR TITLE
new: configurable max APDU on the BACnet/IPv6 transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,9 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - Multi-targeting: `net48;netstandard2.0;net8.0;net10.0`.
 - New packages: `BACnet.Ethernet`, `BACnet.Serial`, `BACnet.Logging.CommonLogging`.
 - Central Package Management, MinVer tag-driven versioning, Source Link + symbol (`.snupkg`) packages.
-- `BacnetIpUdpProtocolTransport` accepts a `maxApdu` constructor parameter to lower the advertised and
-  sent APDU size (e.g. `MAX_APDU1024` keeps every frame, including segmented responses, under a
-  1500-byte MTU instead of relying on IP fragmentation).
+- `BacnetIpUdpProtocolTransport` and `BacnetIpV6UdpProtocolTransport` accept a `maxApdu` constructor
+  parameter to lower the advertised and sent APDU size (e.g. `MAX_APDU1024` keeps every frame,
+  including segmented responses, under a 1500-byte MTU instead of relying on IP fragmentation).
 - CI: multi-OS build matrix; tag-triggered publish to both nuget.org (Trusted Publishing) and GitHub Packages.
 - Runnable sample projects moved in-repo under `Examples/` and built in CI.
 - ASHRAE 135 Annex F golden-vector encode/decode tests.

--- a/Tests/Transport/TransportMaxApduTests.cs
+++ b/Tests/Transport/TransportMaxApduTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// The maxApdu constructor parameter drives MaxAdpuLength, which sizes
+/// segmented responses and is advertised in I-Am / confirmed request headers.
+/// Constructing a transport opens no sockets (that happens in Start).
+/// </summary>
+public class TransportMaxApduTests
+{
+    [Fact]
+    public void Ipv4_transport_defaults_to_1476_and_accepts_lower_max_apdu()
+    {
+        Assert.Equal(BacnetMaxAdpu.MAX_APDU1476,
+            new BacnetIpUdpProtocolTransport(0xBAC0).MaxAdpuLength);
+        Assert.Equal(BacnetMaxAdpu.MAX_APDU1024,
+            new BacnetIpUdpProtocolTransport(0xBAC0, maxApdu: BacnetMaxAdpu.MAX_APDU1024).MaxAdpuLength);
+    }
+
+    [Fact]
+    public void Ipv6_transport_defaults_to_1476_and_accepts_lower_max_apdu()
+    {
+        Assert.Equal(BacnetMaxAdpu.MAX_APDU1476,
+            new BacnetIpV6UdpProtocolTransport(0xBAC0).MaxAdpuLength);
+        Assert.Equal(BacnetMaxAdpu.MAX_APDU1024,
+            new BacnetIpV6UdpProtocolTransport(0xBAC0, maxApdu: BacnetMaxAdpu.MAX_APDU1024).MaxAdpuLength);
+    }
+}

--- a/Transport/BacnetIpV6UdpProtocolTransport.cs
+++ b/Transport/BacnetIpV6UdpProtocolTransport.cs
@@ -45,13 +45,22 @@ public class BacnetIpV6UdpProtocolTransport : BacnetTransportBase
     // Some more complex solutions could avoid this, that's why this property is virtual
     public virtual IPEndPoint LocalEndPoint => (IPEndPoint)_exclusiveConn.Client.LocalEndPoint;
 
+    /// <param name="maxApdu">
+    /// Largest APDU this endpoint sends and advertises (in I-Am and confirmed
+    /// request headers). The default <see cref="BVLCV6.BVLC_MAX_APDU"/> (1476)
+    /// predates UDP/IP overhead — with IPv6's 40-byte header a 1500-byte MTU
+    /// carries only 1452 octets of UDP payload, so full-size frames always
+    /// fragment; pass <see cref="BacnetMaxAdpu.MAX_APDU1024"/> to keep every
+    /// frame, including segmented responses, below the MTU.
+    /// </param>
     public BacnetIpV6UdpProtocolTransport(int port, int vMac = -1, bool useExclusivePort = false,
-        bool dontFragment = false, int maxPayload = 1472, string localEndpointIp = "")
+        bool dontFragment = false, int maxPayload = 1472, string localEndpointIp = "",
+        BacnetMaxAdpu maxApdu = BVLCV6.BVLC_MAX_APDU)
     {
         SharedPort = port;
         MaxBufferLength = maxPayload;
         Type = BacnetAddressTypes.IPV6;
-        MaxAdpuLength = BVLCV6.BVLC_MAX_APDU;
+        MaxAdpuLength = maxApdu;
 
         // Two frames type, unicast with 10 bytes or broadcast with 7 bytes
         // Here it's the biggest header, resize will be done after, if needed


### PR DESCRIPTION
Mirrors #198's `maxApdu` constructor parameter from `BacnetIpUdpProtocolTransport` onto `BacnetIpV6UdpProtocolTransport`, completing the transport symmetry.

The IPv6 case is actually stronger than IPv4: with the 40-byte IPv6 header, a 1500-byte MTU carries only **1452 octets** of UDP payload — so full-size 1476-octet APDUs *always* fragment (IPv4 at least fit exactly with a 2-byte local NPDU). And unlike IPv4, IPv6 routers never fragment in transit, so path-MTU trouble surfaces as silent drops rather than reassembled delivery. `maxApdu: MAX_APDU1024` keeps every frame, including segmented responses, below the MTU.

`MaxAdpuLength` drives both what I-Am advertises and how responses are segmented, so the endpoint stays self-consistent — same mechanism verified end-to-end (zero fragmentation counters) in the #198 container tests for IPv4.

Includes constructor tests for both transports (construction opens no sockets; `Start()` does).

No behavior change without the parameter — the default remains `BVLC_MAX_APDU` (1476).
