### PR TITLE
fix: decode all BACnetTimeStamp choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,12 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - OS detection in the UDP transport now uses `RuntimeInformation.IsOSPlatform`, fixing `DontFragment` on
   macOS (#91) and making the Windows-only `SIO_UDP_CONNRESET` guard analyzer-clean.
 - Response correlation matches by invoke-id per ASHRAE 135 §20.1.2.6 (#141, #149).
+- Event notifications stamped with a `time` or `sequenceNumber` BACnetTimeStamp are now decoded, so
+  `OnEventNotify` fires for them (#32, #67): the decoders assumed the `dateTime` choice only, making
+  notifications from devices without clocks (which commonly stamp with sequence numbers) invisible.
+  The same fix applies to `DecodeAlarmAcknowledge` (an ack echoes the event's timestamp choice) and
+  the GetEventInformation timestamps; new `ASN1.bacapp_decode_timestamp` handles the full CHOICE and
+  `BacnetGenericTime.Tag`/`Sequence` are now populated on decode.
 - All unconfirmed sends now address peers behind a BACnet router correctly (NPDU destination =
   the peer's network/MAC, frame to the fronting router — the same addressing the `Iam()` fix
   established): directed `WhoIs`/`WhoHas`, `SendUnconfirmedEventNotification`,

--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -799,6 +799,68 @@ public class ASN1
         }
     }
 
+    /// <summary>
+    /// Decode a BACnetTimeStamp CHOICE: time [0], sequenceNumber [1] or dateTime [2]
+    /// (the counterpart of <see cref="bacapp_encode_timestamp"/>).
+    /// </summary>
+    public static int bacapp_decode_timestamp(byte[] buffer, int offset, out BacnetGenericTime value)
+    {
+        value = default;
+
+        if (decode_is_context_tag(buffer, offset, 0)) /* time */
+        {
+            var len = decode_tag_number_and_value(buffer, offset, out _, out _);
+            len += decode_bacnet_time(buffer, offset + len, out var time);
+            value = new BacnetGenericTime(time, BacnetTimestampTags.TIME_STAMP_TIME);
+            return len;
+        }
+
+        if (decode_is_context_tag(buffer, offset, 1)) /* sequenceNumber */
+        {
+            var len = decode_tag_number_and_value(buffer, offset, out _, out var lenValue);
+            len += decode_unsigned(buffer, offset + len, lenValue, out uint sequence);
+            if (sequence > ushort.MaxValue)
+                return -1;
+            value = new BacnetGenericTime(default, BacnetTimestampTags.TIME_STAMP_SEQUENCE, (ushort)sequence);
+            return len;
+        }
+
+        if (decode_is_opening_tag_number(buffer, offset, 2)) /* dateTime */
+        {
+            var len = 1; /* opening tag 2 */
+            len += decode_application_date(buffer, offset + len, out var date);
+            len += decode_application_time(buffer, offset + len, out var time);
+            value = new BacnetGenericTime(
+                new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute, time.Second, time.Millisecond),
+                BacnetTimestampTags.TIME_STAMP_DATETIME);
+            if (!decode_is_closing_tag_number(buffer, offset + len, 2))
+                return -1;
+            return len + 1; /* closing tag 2 */
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Decode a context-wrapped BACnetTimeStamp, e.g. 'timeStamp [3]' of an event notification
+    /// or 'eventTimeStamp [3]' of an AcknowledgeAlarm.
+    /// </summary>
+    public static int bacapp_decode_context_timestamp(byte[] buffer, int offset, byte tagNumber, out BacnetGenericTime value)
+    {
+        value = default;
+
+        if (!decode_is_opening_tag_number(buffer, offset, tagNumber))
+            return -1;
+        var len = 1; /* opening tag */
+        var stampLen = bacapp_decode_timestamp(buffer, offset + len, out value);
+        if (stampLen < 0)
+            return -1;
+        len += stampLen;
+        if (!decode_is_closing_tag_number(buffer, offset + len, tagNumber))
+            return -1;
+        return len + 1; /* closing tag */
+    }
+
     public static void encode_application_character_string(EncodeBuffer buffer, string value)
     {
         var tmp = new EncodeBuffer();

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -206,30 +206,17 @@ public class Services
         len += ASN1.decode_context_object_id(buffer, offset + len, 1, out ushort type, out eventObjectIdentifier.instance);
         eventObjectIdentifier.type = (BacnetObjectTypes)type;
         len += ASN1.decode_context_enumerated(buffer, offset + len, 2, out eventStateAcked);
-        if (ASN1.decode_is_context_tag(buffer, offset + len, 3))
-        {
-            len += 2; // opening Tag 3 then 2
-            len += ASN1.decode_application_date(buffer, offset + len, out var date);
-            len += ASN1.decode_application_time(buffer, offset + len, out var time);
-            eventTimeStamp.Time = new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute,
-                time.Second, time.Millisecond);
-
-            len += 2; // closing tag 2 then 3
-        }
-        else
+        /* eventTimeStamp [3] echoes the BACnetTimeStamp CHOICE of the event being acknowledged,
+           so it is not necessarily a date+time */
+        var stampLen = ASN1.bacapp_decode_context_timestamp(buffer, offset + len, 3, out eventTimeStamp);
+        if (stampLen < 0)
             return -1;
+        len += stampLen;
         len += ASN1.decode_context_character_string(buffer, offset + len, 256, 4, out ackSource);
-        if (ASN1.decode_is_context_tag(buffer, offset + len, 5))
-        {
-            len += 2; // opening Tag 5 then 2
-            len += ASN1.decode_application_date(buffer, offset + len, out var date);
-            len += ASN1.decode_application_time(buffer, offset + len, out var time);
-            ackTimeStamp.Time = new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute,
-                time.Second, time.Millisecond);
-            len += 2; // closing tag 2 then 5
-        }
-        else
+        stampLen = ASN1.bacapp_decode_context_timestamp(buffer, offset + len, 5, out ackTimeStamp);
+        if (stampLen < 0)
             return -1;
+        len += stampLen;
         return len;
     }
 
@@ -816,19 +803,14 @@ public class Services
         else
             return -1;
 
-        /*  tag 3 - timeStamp */
-        if (ASN1.decode_is_context_tag(buffer, offset + len, 3))
+        /* tag 3 - timeStamp: a BACnetTimeStamp CHOICE of time, sequence number or date+time
+           (devices without clocks commonly stamp their events with sequence numbers) */
         {
-            len += 2; // opening Tag 3 then 2
-            len += ASN1.decode_application_date(buffer, offset + len, out var date);
-            len += ASN1.decode_application_time(buffer, offset + len, out var time);
-            eventData.timeStamp.Time = new DateTime(date.Year, date.Month, date.Day, time.Hour, time.Minute,
-                time.Second, time.Millisecond);
-
-            len += 2; // closing tag 2 then 3
+            var stampLen = ASN1.bacapp_decode_context_timestamp(buffer, offset + len, 3, out eventData.timeStamp);
+            if (stampLen < 0)
+                return -1;
+            len += stampLen;
         }
-        else
-            return -1;
 
         /* tag 4 - noticicationClass */
         if (ASN1.decode_is_context_tag(buffer, offset + len, 4))
@@ -1331,18 +1313,23 @@ public class Services
 
                 for (var i = 0; i < 3; i++)
                 {
-                    len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue); // opening tag
-
-                    if (tagNumber != (byte)BacnetApplicationTags.BACNET_APPLICATION_TAG_NULL)
+                    // each entry is a BACnetTimeStamp CHOICE (time, sequence number or date+time);
+                    // some devices send a Null for transitions that never happened
+                    if (ASN1.decode_is_application_tag(buffer, offset + len, BacnetApplicationTags.BACNET_APPLICATION_TAG_NULL))
                     {
-                        len += ASN1.decode_application_date(buffer, offset + len, out var date);
-                        len += ASN1.decode_application_time(buffer, offset + len, out var time);
-                        var timestamp = date.Date + time.TimeOfDay;
-                        value.eventTimeStamps[i] = new BacnetGenericTime(timestamp, BacnetTimestampTags.TIME_STAMP_DATETIME);
-                        len++; // closing tag
+                        len += ASN1.decode_tag_number_and_value(buffer, offset + len, out tagNumber, out lenValue);
+                        len += (int)lenValue;
                     }
                     else
-                        len += (int)lenValue;
+                    {
+                        var stampLength = ASN1.bacapp_decode_timestamp(buffer, offset + len, out value.eventTimeStamps[i]);
+                        if (stampLength < 0)
+                        {
+                            moreEvent = false;
+                            return -1;
+                        }
+                        len += stampLength;
+                    }
                 }
 
                 len++;  // closing Tag 3

--- a/Tests/Serialize/EventTimeStampTests.cs
+++ b/Tests/Serialize/EventTimeStampTests.cs
@@ -1,0 +1,114 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// BACnetTimeStamp is a CHOICE of time [0], sequenceNumber [1] and dateTime [2]. The decoders
+/// only handled dateTime: event notifications and alarm acknowledgements stamped with a time or
+/// a sequence number (common on devices without clocks) failed to decode, so OnEventNotify never
+/// fired for them.
+/// </summary>
+public class EventTimeStampTests
+{
+    private static BacnetEventNotificationData MakeEventData(BacnetGenericTime timeStamp) => new()
+    {
+        processIdentifier = 1,
+        initiatingObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 9876),
+        eventObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1),
+        timeStamp = timeStamp,
+        notificationClass = 1,
+        priority = 100,
+        eventType = BacnetEventTypes.EVENT_OUT_OF_RANGE,
+        notifyType = BacnetNotifyTypes.NOTIFY_ALARM,
+        ackRequired = false,
+        fromState = BacnetEventStates.EVENT_STATE_NORMAL,
+        toState = BacnetEventStates.EVENT_STATE_HIGH_LIMIT,
+        outOfRange_exceedingValue = 88.5f,
+        outOfRange_statusFlags = BacnetBitString.Parse("0000"),
+        outOfRange_deadband = 0f,
+        outOfRange_exceededLimit = 50f
+    };
+
+    private static BacnetEventNotificationData RoundTrip(BacnetGenericTime timeStamp)
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeEventNotifyUnconfirmed(buffer, MakeEventData(timeStamp));
+
+        var len = Services.DecodeEventNotifyData(buffer.buffer, 0, buffer.offset, out var decoded);
+        Assert.True(len >= 0, "DecodeEventNotifyData failed");
+        return decoded;
+    }
+
+    [Fact]
+    public void Event_with_sequence_number_timestamp_decodes()
+    {
+        var decoded = RoundTrip(new BacnetGenericTime(default, BacnetTimestampTags.TIME_STAMP_SEQUENCE, 1234));
+
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_SEQUENCE, decoded.timeStamp.Tag);
+        Assert.Equal(1234, decoded.timeStamp.Sequence);
+        Assert.Equal(88.5f, decoded.outOfRange_exceedingValue);
+    }
+
+    [Fact]
+    public void Event_with_time_timestamp_decodes()
+    {
+        var timeOfDay = new DateTime(1, 1, 1, 11, 22, 33, 440);
+        var decoded = RoundTrip(new BacnetGenericTime(timeOfDay, BacnetTimestampTags.TIME_STAMP_TIME));
+
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_TIME, decoded.timeStamp.Tag);
+        Assert.Equal(timeOfDay.TimeOfDay, decoded.timeStamp.Time.TimeOfDay);
+    }
+
+    [Fact]
+    public void Event_with_datetime_timestamp_decodes()
+    {
+        var stamp = new DateTime(2026, 7, 5, 11, 22, 33, 440);
+        var decoded = RoundTrip(new BacnetGenericTime(stamp, BacnetTimestampTags.TIME_STAMP_DATETIME));
+
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_DATETIME, decoded.timeStamp.Tag);
+        Assert.Equal(stamp, decoded.timeStamp.Time);
+    }
+
+    [Fact]
+    public void Alarm_acknowledge_with_mixed_timestamp_choices_decodes()
+    {
+        // the ack echoes the event's (sequence) stamp; the ack itself is dated
+        var eventStamp = new BacnetGenericTime(default, BacnetTimestampTags.TIME_STAMP_SEQUENCE, 77);
+        var ackStamp = new BacnetGenericTime(new DateTime(2026, 7, 5, 12, 0, 0), BacnetTimestampTags.TIME_STAMP_DATETIME);
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeAlarmAcknowledge(buffer, 55,
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), 3, "operator", eventStamp, ackStamp);
+
+        var len = Services.DecodeAlarmAcknowledge(buffer.buffer, 0, buffer.offset, out var ackProcess,
+            out var objectId, out var stateAcked, out var source, out var decodedEvent, out var decodedAck);
+
+        Assert.True(len >= 0, "DecodeAlarmAcknowledge failed");
+        Assert.Equal(55u, ackProcess);
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_SEQUENCE, decodedEvent.Tag);
+        Assert.Equal(77, decodedEvent.Sequence);
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_DATETIME, decodedAck.Tag);
+        Assert.Equal(ackStamp.Time, decodedAck.Time);
+        Assert.Equal("operator", source);
+    }
+
+    [Fact]
+    public void Timestamp_choice_wire_formats_decode()
+    {
+        // sequenceNumber [1]: context tag 1, length 1, value 1
+        var len = ASN1.bacapp_decode_timestamp(new byte[] { 0x19, 0x01 }, 0, out var sequence);
+        Assert.Equal(2, len);
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_SEQUENCE, sequence.Tag);
+        Assert.Equal(1, sequence.Sequence);
+
+        // time [0]: context tag 0, length 4, 11:22:33.44
+        len = ASN1.bacapp_decode_timestamp(new byte[] { 0x0C, 11, 22, 33, 44 }, 0, out var time);
+        Assert.Equal(5, len);
+        Assert.Equal(BacnetTimestampTags.TIME_STAMP_TIME, time.Tag);
+        Assert.Equal(new TimeSpan(0, 11, 22, 33, 440), time.Time.TimeOfDay);
+
+        // an unknown choice fails cleanly
+        Assert.Equal(-1, ASN1.bacapp_decode_timestamp(new byte[] { 0x39, 0x01 }, 0, out _));
+    }
+}


### PR DESCRIPTION
Root cause of the "OnEventNotify never fires" reports: `DecodeEventNotifyData` hardcoded the **`dateTime [2]`** alternative of the `BACnetTimeStamp` CHOICE (blind `len += 2` around a date+time read). Event notifications stamped with **`time [0]`** or **`sequenceNumber [1]`** — the latter common on devices without clocks — failed to decode, so `OnEventNotify` silently never fired for them.

## How it was found

Cross-stack test: a [BACpypes3](https://github.com/JoelBender/BACpypes3) (Python) device and a `BacnetClient` listener run in two Docker containers on isolated networks, joined by the [bacnet-stack](https://github.com/bacnet-stack/bacnet-stack) `router` app, so all traffic takes a realistic path through a BACnet router. The Python device sends unconfirmed OUT_OF_RANGE event notifications with a selectable timestamp choice; the listener reports whether `OnEventNotify` fired or only the raw `OnUnconfirmedServiceRequest` arrived:

| BACnetTimeStamp choice | before | after |
|---|---|---|
| `dateTime [2]` | ✅ decodes | ✅ decodes |
| `sequenceNumber [1]` | ❌ raw frame seen, `OnEventNotify` never fires | ✅ decodes |
| `time [0]` | ❌ same | ✅ decodes |

Same-stack (C#↔C#) tests never caught this because the encoder side also only ever sent `dateTime` — the same mutual-blind-spot pattern as #199.

## Changes

- New `ASN1.bacapp_decode_timestamp` / `bacapp_decode_context_timestamp`: decode the full CHOICE, symmetric to the existing (already choice-aware) `bacapp_encode_timestamp` / `bacapp_encode_context_timestamp`. `BacnetGenericTime.Tag` and `.Sequence` are now populated on decode instead of defaulting.
- `DecodeEventNotifyData`: timeStamp `[3]` decoded via the new helper.
- `DecodeAlarmAcknowledge`: identical blind pattern fixed for **both** of its timestamps — per 135, an acknowledgment echoes the acknowledged event's timestamp choice, so a sequence-stamped event made its own ack undecodable.
- GetEventInformation ACK: the three per-transition timestamps are also CHOICEs; additionally a `time [0]` entry was previously mistaken for a `Null` entry (tag-number comparison without the class bit).

## Verification

- Unit: 165/165, 5 new in `EventTimeStampTests` — encoder round-trips for all three choices, an alarm-ack with mixed choices (sequence event stamp + dateTime ack stamp), and wire-format byte anchors (`19 01` sequence, `0C hh mm ss cc` time) plus a clean `-1` on an unknown choice.
- The BACpypes3→router→listener test above: all three timestamp choices now decode end-to-end (previously `sequence` and `time` failed).

Closes #32. Closes #67.
