### PR TITLE
fix: tolerate partially-wildcarded Date and Time values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   The same fix applies to `DecodeAlarmAcknowledge` (an ack echoes the event's timestamp choice) and
   the GetEventInformation timestamps; new `ASN1.bacapp_decode_timestamp` handles the full CHOICE and
   `BacnetGenericTime.Tag`/`Sequence` are now populated on decode.
+- Partially-wildcarded Date and Time values no longer throw during decode (#103): any octet may
+  individually be X'FF' (unspecified) and Date carries special values (odd/even month, last day —
+  ASHRAE 135 §20.2.12/§20.2.13). Wildcarded time components are clamped to zero and unrepresentable
+  dates degrade to `DateTime.MinValue`, matching YABE's behaviour; previously the exception was
+  swallowed upstream, e.g. silently dropping event notifications stamped with a wildcarded time.
 - All unconfirmed sends now address peers behind a BACnet router correctly (NPDU destination =
   the peer's network/MAC, frame to the fronting router — the same addressing the `Iam()` fix
   established): directed `WhoIs`/`WhoHas`, `SendUnconfirmedEventNotification`,

--- a/Serialize/ASN1.cs
+++ b/Serialize/ASN1.cs
@@ -1681,9 +1681,18 @@ public class ASN1
         int wday = buffer[offset + 3];
 
         if (month == 0xFF && day == 0xFF && wday == 0xFF && year - 1900 == 0xFF)
+        {
             bdate = new DateTime(1, 1, 1);
+        }
         else
-            bdate = new DateTime(year, month, day);
+        {
+            // any field may also individually be X'FF' (unspecified), and month/day carry special
+            // values (13/14 = odd/even month, 32/33/34 = last/odd/even day - 135 20.2.12); none of
+            // those are representable in a DateTime, so degrade to the minimum date like the
+            // fully-wildcarded case instead of throwing
+            try { bdate = new DateTime(year, month, day); }
+            catch { bdate = new DateTime(1, 1, 1); }
+        }
 
         return 4;
     }
@@ -1709,7 +1718,12 @@ public class ASN1
         }
         else
         {
-            if (hundredths > 100) hundredths = 0; // sometimes set to 255
+            // any octet may individually be X'FF' (unspecified - 135 20.2.13): clamp wildcarded
+            // components to zero so the remaining specified fields survive instead of throwing
+            if (hour > 23) hour = 0;
+            if (min > 59) min = 0;
+            if (sec > 59) sec = 0;
+            if (hundredths > 99) hundredths = 0; // sometimes set to 255
             btime = new DateTime(1, 1, 1, hour, min, sec, hundredths * 10);
         }
         return 4;

--- a/Tests/Serialize/DateTimeWildcardTests.cs
+++ b/Tests/Serialize/DateTimeWildcardTests.cs
@@ -1,0 +1,62 @@
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Date and Time octets may individually be X'FF' (unspecified), and Date carries special values
+/// (month 13/14 = odd/even, day 32/33/34 = last/odd/even - ASHRAE 135 §20.2.12/§20.2.13). Real
+/// devices send these for "don't care" fields; the decoders previously threw from the DateTime
+/// constructor, which upstream code swallows - e.g. an event notification stamped with a
+/// partially-wildcarded time silently never reached OnEventNotify.
+/// </summary>
+public class DateTimeWildcardTests
+{
+    [Fact]
+    public void Time_with_wildcard_seconds_decodes_with_specified_fields_kept()
+    {
+        var len = ASN1.decode_bacnet_time(new byte[] { 11, 22, 0xFF, 0xFF }, 0, out var time);
+
+        Assert.Equal(4, len);
+        Assert.Equal(new TimeSpan(11, 22, 0), time.TimeOfDay);
+    }
+
+    [Fact]
+    public void Time_with_wildcard_hour_decodes_with_specified_fields_kept()
+    {
+        var len = ASN1.decode_bacnet_time(new byte[] { 0xFF, 22, 33, 44 }, 0, out var time);
+
+        Assert.Equal(4, len);
+        Assert.Equal(new TimeSpan(0, 0, 22, 33, 440), time.TimeOfDay);
+    }
+
+    [Fact]
+    public void Fully_wildcarded_time_keeps_the_minimum_sentinel()
+    {
+        ASN1.decode_bacnet_time(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF }, 0, out var time);
+
+        Assert.Equal(new DateTime(1, 1, 1), time);
+    }
+
+    [Theory]
+    [InlineData(new byte[] { 126, 7, 0xFF, 0xFF })] // 2026-07, day unspecified
+    [InlineData(new byte[] { 126, 13, 15, 0xFF })]  // odd months (13)
+    [InlineData(new byte[] { 126, 7, 32, 0xFF })]   // last day of month (32)
+    public void Unrepresentable_date_specials_degrade_to_minimum_instead_of_throwing(byte[] octets)
+    {
+        var len = ASN1.decode_date(octets, 0, out var date);
+
+        Assert.Equal(4, len);
+        Assert.Equal(new DateTime(1, 1, 1), date);
+    }
+
+    [Fact]
+    public void Fully_specified_date_and_time_still_decode_exactly()
+    {
+        ASN1.decode_date(new byte[] { 126, 7, 5, 7 }, 0, out var date);
+        ASN1.decode_bacnet_time(new byte[] { 11, 22, 33, 44 }, 0, out var time);
+
+        Assert.Equal(new DateTime(2026, 7, 5), date);
+        Assert.Equal(new TimeSpan(0, 11, 22, 33, 440), time.TimeOfDay);
+    }
+}


### PR DESCRIPTION
Any Date or Time octet may individually be `X'FF'` (unspecified), and Date additionally carries special values — odd/even month (13/14), last/odd/even day (32/33/34) — per ASHRAE 135 §20.2.12/§20.2.13. `decode_date` and `decode_bacnet_time` only recognised the fully-wildcarded (all-FF) form; anything partial reached the `DateTime` constructor and threw. Upstream code swallows that exception, so the symptoms are silent: an event notification stamped with a partially-wildcarded time never raises `OnEventNotify`, and reading a wildcarded Time/Date value fails.

## Reproduction

A [BACpypes3](https://github.com/JoelBender/BACpypes3) (Python) device and this library's client run in Docker containers on isolated networks joined by the [bacnet-stack](https://github.com/bacnet-stack/bacnet-stack) `router` app, so traffic takes a realistic path through a BACnet router. The Python device serves `Time((11,22,255,255))` (seconds unspecified) and `Date((126,7,255,255))` (day unspecified) values, and sends OUT_OF_RANGE event notifications stamped with the wildcarded time:

| Test | before | after |
|---|---|---|
| read Time value, seconds unspecified | ❌ `...un-representable DateTime` | ✅ `11:22:00` (specified fields kept) |
| read Date value, day unspecified | ❌ `...un-representable DateTime` | ✅ degrades to minimum date |
| event stamped with wildcarded time | ❌ `OnEventNotify` never fires | ✅ received and decoded |

## Changes

- `decode_bacnet_time`: wildcarded components are clamped to zero so the specified fields survive — adapted from Etienne Dechamps' patch in YABE (svn@383), with corrected bounds (`> 23/59/59` rather than `> 24/60/60`) and our all-FF → minimum-sentinel branch kept (YABE dropped it, making a fully-unspecified time indistinguishable from midnight).
- `decode_date`: dates a `DateTime` cannot represent (partial wildcards and the odd/even/last special values) degrade to the minimum date instead of throwing — YABE's approach (svn@577).
- 7 new unit tests with the exact wildcard octets, including the "specified fields survive" and "valid values still exact" cases.

Representing wildcards *losslessly* (a value that means "any day in July 2026") requires dedicated date/time types instead of `DateTime` — the IPECON fork went that way with a breaking `BacnetDate` type; deferred to 5.0.

Closes #103.
