### PR TITLE
fix: detect duplicate confirmed requests instead of re-executing them

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -48,6 +48,15 @@ public class BacnetClient : IDisposable
     private ConcurrentDictionary<byte, object> _locksPerInvokeId = new();
     private Dictionary<byte, byte> _expectedSegmentsPerInvokeId = new();
 
+    private readonly Dictionary<(BacnetAddress Address, byte InvokeId), RecentRequest> _recentRequests = new();
+
+    private class RecentRequest
+    {
+        public byte[] Request;
+        public byte[] Response;
+        public DateTime LastSeen;
+    }
+
     public const int DEFAULT_UDP_PORT = 0xBAC0;
     public const int DEFAULT_TIMEOUT = 1000;
     public const int DEFAULT_RETRIES = 3;
@@ -60,6 +69,14 @@ public class BacnetClient : IDisposable
     public byte ProposedWindowSize { get; set; } = 10;
     public bool ForceWindowSize { get; set; }
     public bool DefaultSegmentationHandling { get; set; } = true;
+
+    /// <summary>
+    /// Detect retransmitted confirmed requests (same source, invoke-id and content) as required by
+    /// ASHRAE 135 §5.4.5 and answer them by retransmitting the original response instead of executing
+    /// the service again. Without this, a request whose acknowledgment was lost or late is re-executed
+    /// on every client retry - e.g. one retransmitted WriteProperty produces duplicate COV notifications.
+    /// </summary>
+    public bool DuplicateRequestDetection { get; set; } = true;
     public ILogger Log { get; set; } = BacnetLogging.CreateLogger<BacnetClient>();
 
     /// <summary>
@@ -224,8 +241,87 @@ public class BacnetClient : IDisposable
     [ThreadStatic]
     private static BacnetMaxAdpu? _currentRequestMaxAdpu;
 
+    /// <summary>
+    /// Duplicate detection for incoming confirmed requests (ASHRAE 135 §5.4.5): a retransmission
+    /// carries the same source, invoke-id and content as a recently seen request and must not execute
+    /// the service again. If the original response already went out it is retransmitted; while the
+    /// original is still being processed the duplicate is dropped. Entries are kept for the span a
+    /// requester keeps retrying (Timeout x (Retries + 1)); a request that reuses an invoke-id with
+    /// different content is a new transaction and replaces the entry.
+    /// </summary>
+    private bool HandleDuplicateRequest(BacnetAddress address, byte invokeId, byte[] buffer, int offset, int length)
+    {
+        var now = DateTime.UtcNow;
+        var retention = TimeSpan.FromMilliseconds(Timeout * (Retries + 1.0));
+
+        lock (_recentRequests)
+        {
+            List<(BacnetAddress, byte)> stale = null;
+            foreach (var kv in _recentRequests)
+                if (now - kv.Value.LastSeen > retention)
+                    (stale ??= new List<(BacnetAddress, byte)>()).Add(kv.Key);
+            if (stale != null)
+                foreach (var key in stale)
+                    _recentRequests.Remove(key);
+
+            if (_recentRequests.TryGetValue((address, invokeId), out var entry)
+                && entry.Request.Length == length && SameContent(entry.Request, buffer, offset, length))
+            {
+                entry.LastSeen = now;
+                if (entry.Response != null)
+                {
+                    Log.LogDebug($"Duplicate request with invoke-id {invokeId} - retransmitting the response");
+                    var frame = new byte[Transport.HeaderLength + entry.Response.Length];
+                    Array.Copy(entry.Response, 0, frame, Transport.HeaderLength, entry.Response.Length);
+                    Transport.Send(frame, Transport.HeaderLength, entry.Response.Length, address, false, 0);
+                }
+                else
+                {
+                    Log.LogDebug($"Duplicate request with invoke-id {invokeId} - still being processed, dropped");
+                }
+                return true;
+            }
+
+            var request = new byte[length];
+            Array.Copy(buffer, offset, request, 0, length);
+            _recentRequests[(address, invokeId)] = new RecentRequest { Request = request, LastSeen = now };
+            return false;
+        }
+
+        static bool SameContent(byte[] stored, byte[] incoming, int offset, int length)
+        {
+            for (var i = 0; i < length; i++)
+                if (stored[i] != incoming[offset + i])
+                    return false;
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// Remember the response sent for a confirmed request so a retransmission of that request can be
+    /// answered with the identical response (see <see cref="HandleDuplicateRequest"/>). Segmented
+    /// responses are not registered - duplicates of their request are dropped instead.
+    /// </summary>
+    private void RegisterResponse(BacnetAddress address, byte invokeId, EncodeBuffer buffer, int length)
+    {
+        if (!DuplicateRequestDetection)
+            return;
+
+        lock (_recentRequests)
+        {
+            if (!_recentRequests.TryGetValue((address, invokeId), out var entry))
+                return;
+
+            entry.Response = new byte[length];
+            Array.Copy(buffer.buffer, Transport.HeaderLength, entry.Response, 0, length);
+        }
+    }
+
     protected void ProcessConfirmedServiceRequest(BacnetAddress address, BacnetPduTypes type, BacnetConfirmedServices service, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, byte invokeId, byte[] buffer, int offset, int length)
     {
+        if (DuplicateRequestDetection && HandleDuplicateRequest(address, invokeId, buffer, offset, length))
+            return;
+
         try
         {
             Log.LogDebug($"ConfirmedServiceRequest {service}");
@@ -1295,6 +1391,7 @@ public class BacnetClient : IDisposable
         NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeError(b, BacnetPduTypes.PDU_TYPE_REJECT, (BacnetConfirmedServices)reason, invokeId);
         Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
+        RegisterResponse(adr, invokeId, b, b.offset - Transport.HeaderLength);
     }
 
     public void SendAbort(BacnetAddress adr, byte invokeId, BacnetAbortReason reason)
@@ -1307,6 +1404,7 @@ public class BacnetClient : IDisposable
         NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeError(b, BacnetPduTypes.PDU_TYPE_ABORT, (BacnetConfirmedServices)reason, invokeId);
         Transport.Send(b.buffer, Transport.HeaderLength, b.offset - Transport.HeaderLength, adr, false, 0);
+        RegisterResponse(adr, invokeId, b, b.offset - Transport.HeaderLength);
     }
 
     public void SynchronizeTime(BacnetAddress adr, DateTime dateTime, BacnetAddress source = null)
@@ -2968,7 +3066,8 @@ public class BacnetClient : IDisposable
         Log.LogDebug($"Sending {ToTitleCase(service)}");
 
         //encode
-        if (EncodeSegment(adr, invokeId, segmentation, service, out var buffer, apduContentEncode))
+        var segmented = EncodeSegment(adr, invokeId, segmentation, service, out var buffer, apduContentEncode);
+        if (segmented)
         {
             //client doesn't support segments
             if (segmentation == null)
@@ -3002,6 +3101,8 @@ public class BacnetClient : IDisposable
 
         //send
         Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.GetLength() - Transport.HeaderLength, adr, false, 0);
+        if (!segmented)
+            RegisterResponse(adr, invokeId, buffer, buffer.GetLength() - Transport.HeaderLength);
     }
 
     public void ReadPropertyResponse(BacnetAddress adr, byte invokeId, Segmentation segmentation, BacnetObjectId objectId, BacnetPropertyReference property, IEnumerable<BacnetValue> value)
@@ -3086,6 +3187,7 @@ public class BacnetClient : IDisposable
         APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR, service, invokeId);
         Services.EncodeError(buffer, errorClass, errorCode);
         Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.offset - Transport.HeaderLength, adr, false, 0);
+        RegisterResponse(adr, invokeId, buffer, buffer.offset - Transport.HeaderLength);
     }
 
     public void PrivateTransferErrorResponse(BacnetAddress adr, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, uint vendorId, uint serviceNumber, byte[] errorParameters = null)
@@ -3096,6 +3198,7 @@ public class BacnetClient : IDisposable
         APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR, BacnetConfirmedServices.SERVICE_CONFIRMED_PRIVATE_TRANSFER, invokeId);
         Services.EncodePrivateTransferError(buffer, errorClass, errorCode, vendorId, serviceNumber, errorParameters);
         Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.offset - Transport.HeaderLength, adr, false, 0);
+        RegisterResponse(adr, invokeId, buffer, buffer.offset - Transport.HeaderLength);
     }
 
     public void SimpleAckResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId)
@@ -3105,6 +3208,7 @@ public class BacnetClient : IDisposable
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeSimpleAck(buffer, BacnetPduTypes.PDU_TYPE_SIMPLE_ACK, service, invokeId);
         Transport.Send(buffer.buffer, Transport.HeaderLength, buffer.offset - Transport.HeaderLength, adr, false, 0);
+        RegisterResponse(adr, invokeId, buffer, buffer.offset - Transport.HeaderLength);
     }
 
     public void SegmentAckResponse(BacnetAddress adr, bool negative, bool server, byte originalInvokeId, byte sequenceNumber, byte actualWindowSize)

--- a/Base/BacnetAddress.cs
+++ b/Base/BacnetAddress.cs
@@ -58,7 +58,9 @@ public class BacnetAddress : ASN1.IEncode
     public override int GetHashCode()
     {
         // DAL this was originally broken...
-        var str = Convert.ToBase64String(adr);
+        // adr may legitimately be null (e.g. a MAC-less source address) and Equals treats two
+        // null-adr addresses as equal, so hash that case consistently instead of throwing
+        var str = adr != null ? Convert.ToBase64String(adr) : "";
         return str.GetHashCode();
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   The same fix applies to `DecodeAlarmAcknowledge` (an ack echoes the event's timestamp choice) and
   the GetEventInformation timestamps; new `ASN1.bacapp_decode_timestamp` handles the full CHOICE and
   `BacnetGenericTime.Tag`/`Sequence` are now populated on decode.
+- Incoming confirmed requests are checked for duplicates as ASHRAE 135 §5.4.5 requires (#35): a
+  retransmitted request (same source, invoke-id and content within the retry window) no longer
+  re-executes the service — the original response is retransmitted instead. Previously every client
+  retry of e.g. a WriteProperty whose ack was lost wrote again and produced duplicate COV
+  notifications. Opt out via `BacnetClient.DuplicateRequestDetection = false`.
 - Partially-wildcarded Date and Time values no longer throw during decode (#103): any octet may
   individually be X'FF' (unspecified) and Date carries special values (odd/even month, last day —
   ASHRAE 135 §20.2.12/§20.2.13). Wildcarded time components are clamped to zero and unrepresentable

--- a/Tests/BacnetClientDuplicateRequestTests.cs
+++ b/Tests/BacnetClientDuplicateRequestTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using System.Linq;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// ASHRAE 135 §5.4.5: a responding BACnet-user must recognise a retransmitted confirmed request
+/// (same source, invoke-id and content) and not execute the service again - the original response
+/// is retransmitted instead. Without this, one retransmitted WriteProperty is written twice and
+/// every subscriber gets duplicate COV notifications.
+/// </summary>
+public class BacnetClientDuplicateRequestTests
+{
+    private static byte[] BuildWritePropertyRequest(byte invokeId, float value)
+    {
+        var buffer = new EncodeBuffer();
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, null);
+        APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY,
+            BacnetMaxSegments.MAX_SEG0, BacnetMaxAdpu.MAX_APDU1476, invokeId);
+        Services.EncodeWriteProperty(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 7),
+            (uint)BacnetPropertyIds.PROP_PRESENT_VALUE, ASN1.BACNET_ARRAY_ALL, 0,
+            new[] { new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL, value) });
+        return buffer.ToArray();
+    }
+
+    private static (BacnetClient Client, RecordingTransport Transport, List<byte> HandledInvokeIds) MakeServer()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport);
+        var handled = new List<byte>();
+        client.OnWritePropertyRequest += (sender, adr, invokeId, objectId, value, maxSegments) =>
+        {
+            handled.Add(invokeId);
+            sender.SimpleAckResponse(adr, BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, invokeId);
+        };
+        client.Start();
+        return (client, transport, handled);
+    }
+
+    private static BacnetAddress Requester() => new(BacnetAddressTypes.IP, "10.0.0.5:47808");
+
+    [Fact]
+    public void Retransmitted_request_is_executed_once_and_response_is_retransmitted()
+    {
+        var (_, transport, handled) = MakeServer();
+        var request = BuildWritePropertyRequest(77, 61.5f);
+
+        transport.Receive(request, Requester());
+        transport.Receive(request, Requester());
+
+        Assert.Equal(new byte[] { 77 }, handled);
+        Assert.Equal(2, transport.Sent.Count); // the SimpleAck and its retransmission
+        Assert.Equal(transport.Sent[0].Frame, transport.Sent[1].Frame);
+    }
+
+    [Fact]
+    public void Different_invoke_ids_are_separate_transactions()
+    {
+        var (_, transport, handled) = MakeServer();
+
+        transport.Receive(BuildWritePropertyRequest(77, 61.5f), Requester());
+        transport.Receive(BuildWritePropertyRequest(78, 61.5f), Requester());
+
+        Assert.Equal(new byte[] { 77, 78 }, handled);
+        Assert.Equal(2, transport.Sent.Count);
+    }
+
+    [Fact]
+    public void Reused_invoke_id_with_different_content_is_a_new_transaction()
+    {
+        var (_, transport, handled) = MakeServer();
+
+        transport.Receive(BuildWritePropertyRequest(77, 61.5f), Requester());
+        transport.Receive(BuildWritePropertyRequest(77, 99.9f), Requester());
+
+        Assert.Equal(new byte[] { 77, 77 }, handled);
+        Assert.Equal(2, transport.Sent.Count);
+    }
+
+    [Fact]
+    public void Requests_from_different_sources_are_separate_transactions()
+    {
+        var (_, transport, handled) = MakeServer();
+        var request = BuildWritePropertyRequest(77, 61.5f);
+
+        transport.Receive(request, Requester());
+        transport.Receive(request, new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.6:47808"));
+
+        Assert.Equal(new byte[] { 77, 77 }, handled);
+    }
+
+    [Fact]
+    public void Detection_can_be_disabled()
+    {
+        var (client, transport, handled) = MakeServer();
+        client.DuplicateRequestDetection = false;
+        var request = BuildWritePropertyRequest(77, 61.5f);
+
+        transport.Receive(request, Requester());
+        transport.Receive(request, Requester());
+
+        Assert.Equal(new byte[] { 77, 77 }, handled);
+    }
+
+    [Fact]
+    public void Unhandled_service_reject_is_retransmitted_for_a_duplicate()
+    {
+        var transport = new RecordingTransport();
+        var client = new BacnetClient(transport); // no handlers -> Reject(UNRECOGNIZED_SERVICE)
+        client.Start();
+        var request = BuildWritePropertyRequest(42, 1f);
+
+        transport.Receive(request, Requester());
+        transport.Receive(request, Requester());
+
+        Assert.Equal(2, transport.Sent.Count);
+        Assert.Equal(transport.Sent[0].Frame, transport.Sent[1].Frame);
+        var npduLen = NPDU.Decode(transport.Sent[0].Frame, 0, out _, out _, out _, out _, out _, out _);
+        Assert.Equal(BacnetPduTypes.PDU_TYPE_REJECT, (BacnetPduTypes)transport.Sent[0].Frame[npduLen] & BacnetPduTypes.PDU_TYPE_MASK);
+    }
+}


### PR DESCRIPTION
A responding BACnet-user shall recognise a retransmitted confirmed request and not execute the service again (ASHRAE 135 §5.4.5). The library dispatched every arriving confirmed-request datagram straight to the application handlers, so each client retry of a request whose acknowledgment was lost or late re-ran the service. That's the mechanism behind the report in #35: one WriteProperty retransmitted on timeout gets written repeatedly, and every subscriber receives the same COV notification "sometimes 5" times.

## Reproduction

Two containers on isolated Docker networks joined by the [bacnet-stack](https://github.com/bacnet-stack/bacnet-stack) `router` app, so traffic takes a realistic path through a BACnet router: a C# device (this library) with a COV subscriber, and a C# test client that subscribes, then transmits **one WriteProperty twice with identical bytes and invoke-id** — exactly what a real client does when the ack is lost.

| | before (`4.0.0-beta.2.6`) | after (`4.0.0-beta.2.7`) |
|---|---|---|
| WriteProperty handler invocations | 2 | **1** |
| COV notifications for the one write | 2 | **1** |
| ack for the retransmission | second execution's ack | **original ack retransmitted** |

## Changes

- Incoming confirmed requests are tracked per (source address, invoke-id) for the span a requester keeps retrying (`Timeout × (Retries + 1)`). A duplicate — same source, invoke-id **and content** — is answered by retransmitting the original response instead of re-executing; while the original is still being processed the duplicate is dropped.
- All response kinds are remembered for retransmission: simple acks, single-frame complex acks, errors, rejects and aborts. Duplicates of a request whose response was segmented are dropped rather than re-answered.
- Reusing an invoke-id with *different* content is treated as the new transaction it is (content comparison makes invoke-id wrap-around by busy clients safe).
- Opt-out: `BacnetClient.DuplicateRequestDetection = false`.
- `BacnetAddress.GetHashCode()` no longer throws when the MAC is null (`Equals` already treated two null-`adr` addresses as equal) — required for keying dictionaries by address, and a latent bug for any consumer doing the same.

## Verification

- Unit: 178/178, 6 new in `BacnetClientDuplicateRequestTests` — retransmission executes once and re-acks identically, distinct invoke-ids / sources / contents stay separate transactions, opt-out works, and an unhandled-service Reject is also retransmitted for a duplicate.
- The router test above, package identity verified inside the images before each run; the full suite (segmented reads in both directions, writes, RPM, COV, Who-Has) re-ran green on the fixed build.

Closes #35.
