### PR TITLE
fix: allow omitting the array index in BacnetPropertyReference

### DIFF
--- a/Base/BacnetPropertyReference.cs
+++ b/Base/BacnetPropertyReference.cs
@@ -5,10 +5,23 @@ public struct BacnetPropertyReference
     public uint propertyIdentifier;
     public uint propertyArrayIndex;        /* optional */
 
-    public BacnetPropertyReference(uint id, uint arrayIndex)
+    /// <param name="id">The property identifier to reference.</param>
+    /// <param name="arrayIndex">
+    /// Index of the array element to reference. Defaults to <see cref="ASN1.BACNET_ARRAY_ALL"/>, which
+    /// omits the optional array index from the encoded request so the whole property is read/written.
+    /// Only pass an explicit index for array properties; index 0 selects the array length, not a scalar
+    /// value, and requesting it for a non-array property yields an error from the peer.
+    /// </param>
+    public BacnetPropertyReference(uint id, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
         propertyIdentifier = id;
         propertyArrayIndex = arrayIndex;
+    }
+
+    /// <inheritdoc cref="BacnetPropertyReference(uint, uint)"/>
+    public BacnetPropertyReference(BacnetPropertyIds id, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
+        : this((uint)id, arrayIndex)
+    {
     }
 
     public BacnetPropertyIds GetPropertyId()

--- a/Tests/Base/BacnetPropertyReferenceTests.cs
+++ b/Tests/Base/BacnetPropertyReferenceTests.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Serialize;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Regression for #101: a <see cref="BacnetPropertyReference"/> built for a scalar (non-array) property
+/// must omit the optional array index so ReadPropertyMultiple/WritePropertyMultiple succeed. The index
+/// is only encoded when it differs from <see cref="ASN1.BACNET_ARRAY_ALL"/>, so the default constructor
+/// value has to be that sentinel — not 0, which selects the array length and errors on scalar properties.
+/// </summary>
+public class BacnetPropertyReferenceTests
+{
+    private const uint PresentValue = (uint)BacnetPropertyIds.PROP_PRESENT_VALUE;
+
+    [Fact]
+    public void OmittingArrayIndex_DefaultsToArrayAll()
+    {
+        var reference = new BacnetPropertyReference(PresentValue);
+
+        Assert.Equal(ASN1.BACNET_ARRAY_ALL, reference.propertyArrayIndex);
+    }
+
+    [Fact]
+    public void EnumOverload_SetsIdentifierAndDefaultsArrayIndex()
+    {
+        var reference = new BacnetPropertyReference(BacnetPropertyIds.PROP_PRESENT_VALUE);
+
+        Assert.Equal(PresentValue, reference.propertyIdentifier);
+        Assert.Equal(ASN1.BACNET_ARRAY_ALL, reference.propertyArrayIndex);
+    }
+
+    [Fact]
+    public void OmittingArrayIndex_DoesNotEncodeArrayIndexTag()
+    {
+        var encoded = EncodeSingleReference(new BacnetPropertyReference(PresentValue));
+
+        // Tag 0 (property identifier) present, no context tag 1 (array index).
+        Assert.Equal(new byte[] { 0x0C, 0x00, 0x00, 0x00, 0x05, 0x1E, 0x09, 0x55, 0x1F }, encoded);
+    }
+
+    [Fact]
+    public void ExplicitArrayIndexZero_EncodesArrayIndexTag()
+    {
+        var encoded = EncodeSingleReference(new BacnetPropertyReference(PresentValue, 0));
+
+        // Same as above but with context tag 1 = 0 (0x19 0x00) selecting the array length.
+        Assert.Equal(new byte[] { 0x0C, 0x00, 0x00, 0x00, 0x05, 0x1E, 0x09, 0x55, 0x19, 0x00, 0x1F }, encoded);
+    }
+
+    private static byte[] EncodeSingleReference(BacnetPropertyReference reference)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_read_access_specification(buffer, new BacnetReadAccessSpecification(
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 5),
+            new List<BacnetPropertyReference> { reference }));
+        return buffer.ToArray();
+    }
+}


### PR DESCRIPTION
Closes #101

## Problem

`ReadPropertyMultipleRequest` (and any code building a `BacnetPropertyReference` by hand) could not read non-array properties. `propertyArrayIndex` is a `uint` that defaults to `0`, and the only constructor forced callers to supply an index. The encoder omits the optional array index **only** when the value equals `ASN1.BACNET_ARRAY_ALL` (`0xFFFFFFFF`) — so a plain `0` was always encoded. Index `0` selects the *array length*, which the peer rejects for scalar (non-array) properties.

The correct "omit the index" sentinel (`ASN1.BACNET_ARRAY_ALL`) was not discoverable from the constructor signature.

## Fix

- Make `arrayIndex` optional, defaulting to `ASN1.BACNET_ARRAY_ALL`, so `new BacnetPropertyReference(id)` reads/writes the whole property.
- Add a `BacnetPropertyIds` overload so scalar references need neither a `(uint)` cast nor an index.
- Document the index-`0` pitfall on the constructor.

**Non-breaking:** every existing call site passes a `(uint)`, a uint const, or a uint variable and binds to the `uint` overload unchanged.

```csharp
new BacnetPropertyReference(BacnetPropertyIds.PROP_PRESENT_VALUE) ;    // whole property, no cast
new BacnetPropertyReference((uint)propId) ;                            // whole property
new BacnetPropertyReference(BacnetPropertyIds.PROP_PRIORITY_ARRAY, 3); // array element 3
```

## Tests

New `Tests/Base/BacnetPropertyReferenceTests.cs`:
- default constructor yields the `BACNET_ARRAY_ALL` sentinel;
- a scalar reference encodes with **no** array-index tag;
- an explicit index `0` **does** emit the tag (array length);
- the enum overload sets the identifier and defaults the index.

Full suite: **176/176 pass**.