### PR TITLE
new: optional array index on WriteProperty requests

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1821,9 +1821,9 @@ public class BacnetClient : IDisposable
 	    res.Dispose();
     }
 
-    public bool WritePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, byte invokeId = 0, byte? priority = null)
+    public bool WritePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
-        using (var result = (BacnetAsyncResult)BeginWritePropertyRequest(adr, objectId, propertyId, valueList, true, invokeId, priority))
+        using (var result = (BacnetAsyncResult)BeginWritePropertyRequest(adr, objectId, propertyId, valueList, true, invokeId, priority, arrayIndex))
         {
             for (var r = 0; r < _retries; r++)
             {
@@ -1861,7 +1861,7 @@ public class BacnetClient : IDisposable
         return false;
     }
 
-    public IAsyncResult BeginWritePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0, byte? priority = null)
+    public IAsyncResult BeginWritePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
         if (priority.HasValue && (priority < 1 || priority > 16))
             throw new ArgumentOutOfRangeException(nameof(priority), "WritePropertyRequest priority must be between 1 and 16");
@@ -1873,7 +1873,7 @@ public class BacnetClient : IDisposable
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, MaxSegments, Transport.MaxAdpuLength, invokeId);
-        Services.EncodeWriteProperty(buffer, objectId, (uint)propertyId, ASN1.BACNET_ARRAY_ALL, priority ?? _writepriority, valueList);
+        Services.EncodeWriteProperty(buffer, objectId, (uint)propertyId, arrayIndex, priority ?? _writepriority, valueList);
 
         //send
         var ret = new BacnetAsyncResult(this, adr, invokeId, buffer.buffer, buffer.offset - Transport.HeaderLength, waitForTransmit, TransmitTimeout);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - PrivateTransfer send/receive support in `BacnetClient` (#154): `PrivateTransferRequest`,
   `SendUnconfirmedPrivateTransfer`, the `OnPrivateTransfer` event, and the
   `PrivateTransferResponse` / `PrivateTransferErrorResponse` replies (ASHRAE 135 clauses 16.2/16.3).
+- `WritePropertyRequest` / `BeginWritePropertyRequest` accept an optional `arrayIndex` to write a
+  single array element (matching `ReadPropertyRequest`), e.g. one slot of a `Priority_Array`.
 
 ### Changed
 - The core package is now pure-managed with no native dependencies (closes the pcap → log4net chain, #112).

--- a/Tests/BacnetClientWritePropertyTests.cs
+++ b/Tests/BacnetClientWritePropertyTests.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// WriteProperty requests over an in-memory transport pair: the optional array index must reach
+/// the device as the property-array-index (context tag [2]) and stay absent by default.
+/// </summary>
+public class BacnetClientWritePropertyTests
+{
+    [Fact]
+    public void Write_property_carries_the_array_index_to_the_device()
+    {
+        var (transportA, transportB) = LoopbackTransport.CreatePair();
+        var client = new BacnetClient(transportA, timeout: 500);
+        var server = new BacnetClient(transportB, timeout: 500);
+        using (client)
+        using (server)
+        {
+            client.Start();
+            server.Start();
+
+            var receivedIndexes = new List<uint>();
+            server.OnWritePropertyRequest += (sender, adr, invokeId, objectId, value, maxSegments) =>
+            {
+                receivedIndexes.Add(value.property.propertyArrayIndex);
+                sender.SimpleAckResponse(adr, BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, invokeId);
+            };
+
+            var analogValue = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1);
+            var value = new[] { new BacnetValue(21.5f) };
+
+            client.WritePropertyRequest(client.Transport.GetBroadcastAddress(), analogValue,
+                BacnetPropertyIds.PROP_PRIORITY_ARRAY, value, arrayIndex: 5);
+            client.WritePropertyRequest(client.Transport.GetBroadcastAddress(), analogValue,
+                BacnetPropertyIds.PROP_PRIORITY_ARRAY, value);
+
+            Assert.Equal(new uint[] { 5, ASN1.BACNET_ARRAY_ALL }, receivedIndexes);
+        }
+    }
+}


### PR DESCRIPTION
`WritePropertyRequest` / `BeginWritePropertyRequest` accept an optional `arrayIndex` parameter (defaulting to `BACNET_ARRAY_ALL`), matching the convention `ReadPropertyRequest` already uses. The wire encoder always supported the property-array-index (context tag [2]); the client API just never exposed it, so writing a single array element - one slot of a `Priority_Array`, one day of a `Weekly_Schedule` - required WritePropertyMultiple.

Source-compatible: the parameter is optional and last. A loopback round-trip test asserts the device receives the index when passed and `BACNET_ARRAY_ALL` when omitted.

Note: touches the same CHANGELOG section as #213, so whichever merges second gets a trivial conflict.