### PR TITLE
new!: CreateObject/DeleteObject request encoders, closing the Annex F gap

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2115,7 +2115,7 @@ public class BacnetClient : IDisposable
 
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply, adr.RoutedSource, adr.RoutedDestination);
         APDU.EncodeConfirmedServiceRequest(buffer, PduConfirmedServiceRequest(), BacnetConfirmedServices.SERVICE_CONFIRMED_CREATE_OBJECT, MaxSegments, Transport.MaxAdpuLength, invokeId);
-        Services.EncodeCreateProperty(buffer, objectId, valueList);
+        Services.EncodeCreateObject(buffer, objectId, valueList);
 
         //send
         var ret = new BacnetAsyncResult(this, adr, invokeId, buffer.buffer, buffer.offset - Transport.HeaderLength, waitForTransmit, TransmitTimeout);
@@ -2166,7 +2166,7 @@ public class BacnetClient : IDisposable
         //NPDU.Encode(b, BacnetNpduControls.PriorityNormalMessage | BacnetNpduControls.ExpectingReply , adr.RoutedSource);
 
         APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST, BacnetConfirmedServices.SERVICE_CONFIRMED_DELETE_OBJECT, MaxSegments, Transport.MaxAdpuLength, invokeId);
-        ASN1.encode_application_object_id(buffer, objectId.type, objectId.instance);
+        Services.EncodeDeleteObject(buffer, objectId);
 
         //send
         var ret = new BacnetAsyncResult(this, adr, invokeId, buffer.buffer, buffer.offset - Transport.HeaderLength, waitForTransmit, TransmitTimeout);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   objects instead of the opaque `CONTEXT_SPECIFIC_DECODED` shapes.
 - **`BacnetDeviceObjectPropertyReference`**: the misspelled public field `deviceIndentifier` is now
   `deviceIdentifier` (the constructor parameter included).
+- **`Services.EncodeCreateProperty` → `EncodeCreateObject`**: the encoder was misnamed - it encodes
+  a CreateObject-Request (BACnet has no CreateProperty service). Same signature; the `BacnetClient`
+  request methods are unaffected.
 
 ### Added
 - Multi-targeting: `net48;netstandard2.0;net8.0;net10.0`.
@@ -34,7 +37,10 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   including segmented responses, under a 1500-byte MTU instead of relying on IP fragmentation).
 - CI: multi-OS build matrix; tag-triggered publish to both nuget.org (Trusted Publishing) and GitHub Packages.
 - Runnable sample projects moved in-repo under `Examples/` and built in CI.
-- ASHRAE 135 Annex F golden-vector encode/decode tests.
+- ASHRAE 135 Annex F golden-vector encode/decode tests - complete: all 62 Annex F example
+  encodings are asserted byte-for-byte.
+- `Services.EncodeCreateObject` overload taking a `BacnetObjectTypes` (CreateObject by object type,
+  the device assigns the instance number) and `Services.EncodeDeleteObject`.
 - PrivateTransfer send/receive support in `BacnetClient` (#154): `PrivateTransferRequest`,
   `SendUnconfirmedPrivateTransfer`, the `OnPrivateTransfer` event, and the
   `PrivateTransferResponse` / `PrivateTransferErrorResponse` replies (ASHRAE 135 clauses 16.2/16.3).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -194,3 +194,18 @@ come back as an unsigned. Timestamps whose time octets are partially wildcarded 
 original octets via the new `BacnetGenericTime.PartialTime` while `Time` keeps the familiar
 best-effort clamped value, and a wildcarded Date+Time property pair merges into the new
 `BacnetDateTime` struct instead of a clamped `DateTime`.
+
+## `Services.EncodeCreateProperty` → `EncodeCreateObject`
+
+This low-level encoder was misnamed: it encodes a **CreateObject-Request** (BACnet has no
+CreateProperty service). It keeps its signature under the correct name:
+
+```diff
+- Services.EncodeCreateProperty(buffer, objectId, values);
++ Services.EncodeCreateObject(buffer, objectId, values);
+```
+
+It also gains an overload taking a `BacnetObjectTypes`, encoding the request's objectType choice
+("create an object of this type, the device assigns the instance number"), and DeleteObject gets
+its counterpart `Services.EncodeDeleteObject`. The `BacnetClient` request methods
+(`CreateObjectRequest`, `DeleteObjectRequest` and their `Begin`/`End` forms) are unchanged.

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -421,16 +421,32 @@ public class Services
     }
 
     // by Christopher Günter
-    public static void EncodeCreateProperty(EncodeBuffer buffer, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList)
+    public static void EncodeCreateObject(EncodeBuffer buffer, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList)
     {
-        /* Tag 1: sequence of WriteAccessSpecification */
+        /* Tag 0: objectSpecifier - choice [1] objectIdentifier */
         ASN1.encode_opening_tag(buffer, 0);
         ASN1.encode_context_object_id(buffer, 1, objectId.type, objectId.instance);
         ASN1.encode_closing_tag(buffer, 0);
 
+        EncodeListOfInitialValues(buffer, valueList);
+    }
+
+    public static void EncodeCreateObject(EncodeBuffer buffer, BacnetObjectTypes objectType, ICollection<BacnetPropertyValue> valueList)
+    {
+        /* Tag 0: objectSpecifier - choice [0] objectType, the device assigns the instance number */
+        ASN1.encode_opening_tag(buffer, 0);
+        ASN1.encode_context_enumerated(buffer, 0, (uint)objectType);
+        ASN1.encode_closing_tag(buffer, 0);
+
+        EncodeListOfInitialValues(buffer, valueList);
+    }
+
+    private static void EncodeListOfInitialValues(EncodeBuffer buffer, ICollection<BacnetPropertyValue> valueList)
+    {
         if (valueList == null)
             return;
 
+        /* Tag 1: listOfInitialValues - sequence of BACnetPropertyValue */
         ASN1.encode_opening_tag(buffer, 1);
 
         foreach (var pValue in valueList)
@@ -2505,6 +2521,11 @@ public class Services
         valuesRefs = _values;
 
         return len;
+    }
+
+    public static void EncodeDeleteObject(EncodeBuffer buffer, BacnetObjectId objectId)
+    {
+        ASN1.encode_application_object_id(buffer, objectId.type, objectId.instance);
     }
 
     public static int DecodeDeleteObject(byte[] buffer, int offset, int apduLen, out BacnetObjectId objectId)

--- a/Tests/Serialize/AshraeAnnexF3Tests.cs
+++ b/Tests/Serialize/AshraeAnnexF3Tests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO.BACnet.Serialize;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.BACnet.Tests;
@@ -14,6 +15,7 @@ public class AshraeAnnexF3Tests
     private static readonly BacnetObjectId Ai16 = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 16);
     private const uint PresentValue = (uint)BacnetPropertyIds.PROP_PRESENT_VALUE;
     private const uint Reliability = (uint)BacnetPropertyIds.PROP_RELIABILITY;
+    private const uint Description = (uint)BacnetPropertyIds.PROP_DESCRIPTION;
 
     [Fact] // F.3.5 - ReadProperty request
     public void F_3_5_ReadProperty_request()
@@ -163,6 +165,37 @@ public class AshraeAnnexF3Tests
         Assert.Equal(new byte[] { 0x20, 0x01, 0x10 }, buffer.ToArray());
     }
 
+    [Fact] // F.3.3 - CreateObject request (File object by type, the device assigns the instance)
+    public void F_3_3_CreateObject_request()
+    {
+        var buffer = new EncodeBuffer();
+        APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_CREATE_OBJECT, BacnetMaxSegments.MAX_SEG0, BacnetMaxAdpu.MAX_APDU1024, 86);
+        Services.EncodeCreateObject(buffer, BacnetObjectTypes.OBJECT_FILE, new List<BacnetPropertyValue>
+        {
+            new BacnetPropertyValue
+            {
+                property = new BacnetPropertyReference(BacnetPropertyIds.PROP_OBJECT_NAME),
+                value = new List<BacnetValue> { new BacnetValue("Trend 1") }
+            },
+            new BacnetPropertyValue
+            {
+                property = new BacnetPropertyReference(BacnetPropertyIds.PROP_FILE_ACCESS_METHOD),
+                value = new List<BacnetValue>
+                {
+                    new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_ENUMERATED,
+                        (uint)BacnetFileAccessMethod.RECORD_ACCESS)
+                }
+            }
+        });
+
+        Assert.Equal(new byte[]
+        {
+            0x00, 0x04, 0x56, 0x0A, 0x0E, 0x09, 0x0A, 0x0F, 0x1E, 0x09, 0x4D, 0x2E, 0x75, 0x08, 0x00, 0x54, 0x72,
+            0x65, 0x6E, 0x64, 0x20, 0x31, 0x2F, 0x09, 0x29, 0x2E, 0x91, 0x00, 0x2F, 0x1F
+        }, buffer.ToArray());
+    }
+
     [Fact] // F.3.3 - CreateObject complex-ack (AnalogValue#13)
     public void F_3_3_CreateObject_ack()
     {
@@ -172,6 +205,17 @@ public class AshraeAnnexF3Tests
         Services.EncodeCreateObjectAcknowledge(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_FILE, 13));
 
         Assert.Equal(new byte[] { 0x30, 0x56, 0x0A, 0xC4, 0x02, 0x80, 0x00, 0x0D }, buffer.ToArray());
+    }
+
+    [Fact] // F.3.4 - DeleteObject request (Group#6)
+    public void F_3_4_DeleteObject_request()
+    {
+        var buffer = new EncodeBuffer();
+        APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_DELETE_OBJECT, BacnetMaxSegments.MAX_SEG0, BacnetMaxAdpu.MAX_APDU1024, 87);
+        Services.EncodeDeleteObject(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_GROUP, 6));
+
+        Assert.Equal(new byte[] { 0x00, 0x04, 0x57, 0x0B, 0xC4, 0x02, 0xC0, 0x00, 0x06 }, buffer.ToArray());
     }
 
     [Fact] // F.3.4 - DeleteObject simple-ack
@@ -184,6 +228,41 @@ public class AshraeAnnexF3Tests
         Assert.Equal(new byte[] { 0x20, 0x57, 0x0B }, buffer.ToArray());
     }
 
+    [Fact] // F.3.4 - DeleteObject error (Group#7 is protected: object / object-deletion-not-permitted)
+    public void F_3_4_DeleteObject_error()
+    {
+        var buffer = new EncodeBuffer();
+        APDU.EncodeError(buffer, BacnetPduTypes.PDU_TYPE_ERROR,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_DELETE_OBJECT, 88);
+        Services.EncodeError(buffer, BacnetErrorClasses.ERROR_CLASS_OBJECT,
+            BacnetErrorCodes.ERROR_CODE_OBJECT_DELETION_NOT_PERMITTED);
+
+        Assert.Equal(new byte[] { 0x50, 0x58, 0x0B, 0x91, 0x01, 0x91, 0x17 }, buffer.ToArray());
+    }
+
+    // List_Of_Group_Members holds ReadAccessSpecifications (object-id [0] + property references [1])
+    private static BacnetValue GroupMember(uint instance, params uint[] propertyIds) =>
+        new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_READ_ACCESS_SPECIFICATION,
+            new BacnetReadAccessSpecification(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, instance),
+                propertyIds.Select(id => new BacnetPropertyReference(id)).ToList()));
+
+    [Fact] // F.3.1 - AddListElement request (add AI#15 to Group#3 List_Of_Group_Members)
+    public void F_3_1_AddListElement_request()
+    {
+        var buffer = new EncodeBuffer();
+        APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_ADD_LIST_ELEMENT, BacnetMaxSegments.MAX_SEG0, BacnetMaxAdpu.MAX_APDU206, 1);
+        Services.EncodeAddListElement(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_GROUP, 3),
+            (uint)BacnetPropertyIds.PROP_LIST_OF_GROUP_MEMBERS, ASN1.BACNET_ARRAY_ALL,
+            new List<BacnetValue> { GroupMember(15, PresentValue, Reliability) });
+
+        Assert.Equal(new byte[]
+        {
+            0x00, 0x02, 0x01, 0x08, 0x0C, 0x02, 0xC0, 0x00, 0x03, 0x19, 0x35, 0x3E, 0x0C, 0x00, 0x00, 0x00, 0x0F,
+            0x1E, 0x09, 0x55, 0x09, 0x67, 0x1F, 0x3F
+        }, buffer.ToArray());
+    }
+
     [Fact] // F.3.1 - AddListElement simple-ack
     public void F_3_1_AddListElement_ack()
     {
@@ -192,6 +271,28 @@ public class AshraeAnnexF3Tests
             BacnetConfirmedServices.SERVICE_CONFIRMED_ADD_LIST_ELEMENT, 1);
 
         Assert.Equal(new byte[] { 0x20, 0x01, 0x08 }, buffer.ToArray());
+    }
+
+    [Fact] // F.3.2 - RemoveListElement request (remove AI#12 and AI#13 from Group#3 List_Of_Group_Members)
+    public void F_3_2_RemoveListElement_request()
+    {
+        var buffer = new EncodeBuffer();
+        APDU.EncodeConfirmedServiceRequest(buffer, BacnetPduTypes.PDU_TYPE_CONFIRMED_SERVICE_REQUEST,
+            BacnetConfirmedServices.SERVICE_CONFIRMED_REMOVE_LIST_ELEMENT, BacnetMaxSegments.MAX_SEG0, BacnetMaxAdpu.MAX_APDU206, 52);
+        // Add/RemoveListElement share the same request production, so both use the one encoder
+        Services.EncodeAddListElement(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_GROUP, 3),
+            (uint)BacnetPropertyIds.PROP_LIST_OF_GROUP_MEMBERS, ASN1.BACNET_ARRAY_ALL, new List<BacnetValue>
+            {
+                GroupMember(12, PresentValue, Reliability, Description),
+                GroupMember(13, PresentValue, Reliability, Description)
+            });
+
+        Assert.Equal(new byte[]
+        {
+            0x00, 0x02, 0x34, 0x09, 0x0C, 0x02, 0xC0, 0x00, 0x03, 0x19, 0x35, 0x3E,
+            0x0C, 0x00, 0x00, 0x00, 0x0C, 0x1E, 0x09, 0x55, 0x09, 0x67, 0x09, 0x1C, 0x1F,
+            0x0C, 0x00, 0x00, 0x00, 0x0D, 0x1E, 0x09, 0x55, 0x09, 0x67, 0x09, 0x1C, 0x1F, 0x3F
+        }, buffer.ToArray());
     }
 
     [Fact] // F.3.2 - RemoveListElement simple-ack


### PR DESCRIPTION
Closes #169

Completes the ASHRAE 135 Annex F golden-vector harvest at 62/62 by adding the 5 vectors that were blocked on missing request-side encoders (F.3.1-F.3.4). Every expected byte sequence was verified against the 135-2016 text, not just against #25's copies.

## Changes

- **`Services.EncodeCreateProperty` renamed to `EncodeCreateObject`** - it always encoded a CreateObject-Request (BACnet has no CreateProperty service; the function was introduced by the "CreateObject service added" commit and its only call site ever was `BeginCreateObjectRequest`). The misleading name is why #169 concluded no encoder existed.
- **New `EncodeCreateObject` overload for the objectType choice** - F.3.3 creates a File object by type, letting the device assign the instance number; the existing code only supported the objectIdentifier choice.
- **New `Services.EncodeDeleteObject`** - the body was previously inlined in `BeginDeleteObjectRequest`.
- **5 new golden-vector tests** in `AshraeAnnexF3Tests`: AddListElement, RemoveListElement, CreateObject and DeleteObject requests plus the DeleteObject error PDU.

## Notes

- F.3.1/F.3.2 needed **no production changes**: `BacnetReadAccessSpecification` already encodes the `List_Of_Group_Members` element production (object-id `[0]` + property references `[1]`), so #25's `BacnetObjectPropertyReference` type was never needed - its name also collides with a different construct in the standard.
- **Breaking**: `Services.EncodeCreateProperty` is public in 3.0.2 and the 4.0 betas; the rename lands inside the 4.0 major bump. `BacnetClient` request methods are unchanged.
- Full suite: 301 tests green.