### PR TITLE
new: non-blocking async request API for all confirmed services

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1759,6 +1759,21 @@ public class BacnetClient : IDisposable
         return false;
     }
 
+    // Awaits a request already put on the wire by a Begin* call, honouring the same per-attempt Timeout
+    // and Retries as the synchronous request methods, but without blocking a thread while the reply is
+    // outstanding. Returns false if every attempt timed out; device-level errors surface through End*.
+    private async Task<bool> SendRequestAsync(BacnetAsyncResult result, CancellationToken cancellationToken)
+    {
+        for (var r = 0; r < _retries; r++)
+        {
+            if (await result.GetResultOrTimeout(Timeout, cancellationToken).ConfigureAwait(false))
+                return true;
+            if (r < _retries - 1)
+                result.Resend();
+        }
+        return false;
+    }
+
     public Task<IList<BacnetValue>> ReadPropertyAsync(BacnetAddress address, BacnetObjectTypes objType, uint objInstance,
         BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
@@ -1766,16 +1781,18 @@ public class BacnetClient : IDisposable
         return ReadPropertyAsync(address, objectId, propertyId, invokeId, arrayIndex);
     }
 
-    public Task<IList<BacnetValue>> ReadPropertyAsync(BacnetAddress address, BacnetObjectId objectId,
+    public async Task<IList<BacnetValue>> ReadPropertyAsync(BacnetAddress address, BacnetObjectId objectId,
         BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
-        return Task<IList<BacnetValue>>.Factory.StartNew(() =>
-        {
-            if (!ReadPropertyRequest(address, objectId, propertyId, out IList<BacnetValue> result, invokeId, arrayIndex))
-                throw new Exception($"Failed to read property {propertyId} of {objectId} from {address}");
+        using var result = (BacnetAsyncResult)BeginReadPropertyRequest(address, objectId, propertyId, true, invokeId, arrayIndex);
+        if (!await SendRequestAsync(result, CancellationToken.None).ConfigureAwait(false))
+            throw new Exception($"Failed to read property {propertyId} of {objectId} from {address}");
 
-            return result;
-        });
+        EndReadPropertyRequest(result, out var valueList, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return valueList;
     }
 
     public IAsyncResult BeginReadPropertyRequest(BacnetAddress address, BacnetObjectId objectId, BacnetPropertyIds propertyId, bool waitForTransmit, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
@@ -1982,19 +1999,22 @@ public class BacnetClient : IDisposable
         return ReadPropertyMultipleAsync(address, objectId, propertyIds);
     }
 
-    public Task<IList<BacnetPropertyValue>> ReadPropertyMultipleAsync(BacnetAddress address,
+    public async Task<IList<BacnetPropertyValue>> ReadPropertyMultipleAsync(BacnetAddress address,
         BacnetObjectId objectId, params BacnetPropertyIds[] propertyIds)
     {
-        var propertyReferences = propertyIds.Select(p =>
-            new BacnetPropertyReference((uint)p, ASN1.BACNET_ARRAY_ALL));
+        var propertyReferences = propertyIds
+            .Select(p => new BacnetPropertyReference((uint)p, ASN1.BACNET_ARRAY_ALL))
+            .ToList();
 
-        return Task<IList<BacnetPropertyValue>>.Factory.StartNew(() =>
-        {
-            if (!ReadPropertyMultipleRequest(address, objectId, propertyReferences.ToList(), out var result))
-                throw new Exception($"Failed to read multiple properties of {objectId} from {address}");
+        using var result = (BacnetAsyncResult)BeginReadPropertyMultipleRequest(address, objectId, propertyReferences, true);
+        if (!await SendRequestAsync(result, CancellationToken.None).ConfigureAwait(false))
+            throw new Exception($"Failed to read multiple properties of {objectId} from {address}");
 
-            return result.Single().values;
-        });
+        EndReadPropertyMultipleRequest(result, out var values, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return values.Single().values;
     }
 
     public IAsyncResult BeginReadPropertyMultipleRequest(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, bool waitForTransmit, byte invokeId = 0)
@@ -2496,15 +2516,7 @@ public class BacnetClient : IDisposable
 
     public Task<IList<BacnetGetEventInformationData>> GetEventsAsync(BacnetAddress address, byte invokeId = 0)
     {
-        IList<BacnetGetEventInformationData> result = new List<BacnetGetEventInformationData>();
-
-        return Task<IList<BacnetGetEventInformationData>>.Factory.StartNew(() =>
-        {
-            if (!GetAlarmSummaryOrEventRequest(address, true, ref result, invokeId))
-                throw new Exception($"Failed to get events from {address}");
-
-            return result;
-        });
+        return GetAlarmSummaryOrEventAsync(address, true, invokeId);
     }
 
     public IAsyncResult BeginGetAlarmSummaryOrEventRequest(BacnetAddress adr, bool getEvent, IList<BacnetGetEventInformationData> alarms, bool waitForTransmit, byte invokeId = 0)
@@ -2764,6 +2776,317 @@ public class BacnetClient : IDisposable
             ex = new Exception("Wait Timeout");
 
         res.Dispose();
+    }
+
+    // ==============================================================================================
+    // Asynchronous request methods.
+    //
+    // Each mirrors its synchronous XxxRequest sibling but never blocks a thread while the reply is
+    // outstanding: the request is put on the wire by the matching Begin* call and awaited through the
+    // TaskCompletionSource in BacnetAsyncResult. Per-attempt Timeout and Retries behave exactly as on
+    // the synchronous path. Failure is reported by throwing — a TimeoutException when every attempt
+    // times out, or the device-reported exception (abort, reject, error or decode failure) otherwise.
+    // The confirmed request itself already carries a source-unique invoke-id, so many of these may be
+    // in flight concurrently on a single client without a lock.
+    // ==============================================================================================
+
+    public async Task<int> WriteFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, int count, byte[] fileBuffer, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginWriteFileRequest(adr, objectId, position, count, fileBuffer, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to write file {objectId} on {adr}");
+
+        EndWriteFileRequest(result, out var newPosition, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return newPosition;
+    }
+
+    public async Task<(int position, uint count, bool endOfFile, byte[] fileBuffer, int fileBufferOffset)> ReadFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReadFileRequest(adr, objectId, position, count, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to read file {objectId} from {adr}");
+
+        EndReadFileRequest(result, out var readCount, out var readPosition, out var endOfFile, out var buffer, out var bufferOffset, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return (readPosition, readCount, endOfFile, buffer, bufferOffset);
+    }
+
+    // Read range by start time
+    public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, DateTime readFrom, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, readFrom, quantity, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to read range of {objectId} from {adr}");
+
+        EndReadRangeRequest(result, out var range, out var count, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return (range, count);
+    }
+
+    // Read range by position
+    public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, uint idxBegin, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, idxBegin, quantity, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to read range of {objectId} from {adr}");
+
+        EndReadRangeRequest(result, out var range, out var count, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return (range, count);
+    }
+
+    public async Task SubscribeCOVAsync(BacnetAddress adr, BacnetObjectId objectId, uint subscribeId, bool cancel, bool issueConfirmedNotifications, uint lifetime, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginSubscribeCOVRequest(adr, objectId, subscribeId, cancel, issueConfirmedNotifications, lifetime, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to subscribe COV of {objectId} on {adr}");
+
+        EndSubscribeCOVRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task SendConfirmedEventNotificationAsync(BacnetAddress adr, BacnetEventNotificationData eventData, byte invokeId = 0, BacnetAddress source = null, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginSendConfirmedEventNotificationRequest(adr, eventData, true, invokeId, source);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to send confirmed event notification to {adr}");
+
+        EndSendConfirmedEventNotificationRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task SubscribePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference monitoredProperty, uint subscribeId, bool cancel, bool issueConfirmedNotifications, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginSubscribePropertyRequest(adr, objectId, monitoredProperty, subscribeId, cancel, issueConfirmedNotifications, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to subscribe property {objectId}.{monitoredProperty} on {adr}");
+
+        EndSubscribePropertyRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task WritePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginWritePropertyRequest(adr, objectId, propertyId, valueList, true, invokeId, priority, arrayIndex);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to write property {propertyId} of {objectId} on {adr}");
+
+        EndWritePropertyRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task WritePropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginWritePropertyMultipleRequest(adr, objectId, valueList, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to write multiple properties of {objectId} on {adr}");
+
+        EndWritePropertyRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task WritePropertyMultipleAsync(BacnetAddress adr, ICollection<BacnetReadAccessResult> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginWritePropertyMultipleRequest(adr, valueList, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to write multiple properties on {adr}");
+
+        EndWritePropertyRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReadPropertyMultipleRequest(adr, objectId, propertyIdAndArrayIndex, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to read multiple properties of {objectId} from {adr}");
+
+        EndReadPropertyMultipleRequest(result, out var values, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return values;
+    }
+
+    public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, IList<BacnetReadAccessSpecification> properties, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReadPropertyMultipleRequest(adr, properties, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to read multiple properties from {adr}");
+
+        EndReadPropertyMultipleRequest(result, out var values, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return values;
+    }
+
+    public async Task CreateObjectAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList = null, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginCreateObjectRequest(adr, objectId, valueList, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to create object {objectId} on {adr}");
+
+        EndCreateObjectRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task DeleteObjectAsync(BacnetAddress adr, BacnetObjectId objectId, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginDeleteObjectRequest(adr, objectId, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to delete object {objectId} on {adr}");
+
+        EndDeleteObjectRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task AddListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginAddListElementRequest(adr, objectId, reference, valueList, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to add list element to {objectId}.{(BacnetPropertyIds)reference.propertyIdentifier} on {adr}");
+
+        EndAddListElementRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task RemoveListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginRemoveListElementRequest(adr, objectId, reference, valueList, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to remove list element from {objectId}.{(BacnetPropertyIds)reference.propertyIdentifier} on {adr}");
+
+        EndAddListElementRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task<byte[]> RawEncodedDecodedPropertyConfirmedAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, BacnetConfirmedServices serviceId, byte[] inOutBuffer = null, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginRawEncodedDecodedPropertyConfirmedRequest(adr, objectId, propertyId, serviceId, inOutBuffer, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed raw confirmed request {serviceId} of {objectId} on {adr}");
+
+        EndRawEncodedDecodedPropertyConfirmedRequest(result, serviceId, out var outBuffer, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return outBuffer;
+    }
+
+    public async Task DeviceCommunicationControlAsync(BacnetAddress adr, uint timeDuration, uint enableDisable, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginDeviceCommunicationControlRequest(adr, timeDuration, enableDisable, password, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed device communication control on {adr}");
+
+        EndDeviceCommunicationControlRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task<(uint vendorId, uint serviceNumber, byte[] resultBlock)> PrivateTransferAsync(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginPrivateTransferRequest(adr, vendorId, serviceNumber, serviceParameters, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed private transfer (vendor {vendorId}, service {serviceNumber}) on {adr}");
+
+        EndPrivateTransferRequest(result, out var outVendorId, out var outServiceNumber, out var resultBlock, out var ex);
+        if (ex != null)
+            throw ex;
+
+        return (outVendorId, outServiceNumber, resultBlock);
+    }
+
+    public async Task<IList<BacnetGetEventInformationData>> GetAlarmSummaryOrEventAsync(BacnetAddress adr, bool getEvent, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        IList<BacnetGetEventInformationData> alarms = new List<BacnetGetEventInformationData>();
+        var currentInvokeId = invokeId;
+        bool moreEvent;
+
+        do
+        {
+            using var result = (BacnetAsyncResult)BeginGetAlarmSummaryOrEventRequest(adr, getEvent, alarms, true, currentInvokeId);
+            if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+                throw new TimeoutException($"Failed to get {(getEvent ? "events" : "alarms")} from {adr}");
+
+            EndGetAlarmSummaryOrEventRequest(result, getEvent, ref alarms, out moreEvent, out var ex);
+            if (ex != null)
+                throw ex;
+
+            currentInvokeId = 0; // let each follow-up "get next" round take a fresh invoke-id
+        } while (moreEvent);
+
+        return alarms;
+    }
+
+    public async Task ReinitializeAsync(BacnetAddress adr, BacnetReinitializedStates state, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginReinitializeRequest(adr, state, password, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to reinitialize {adr}");
+
+        EndReinitializeRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task LifeSafetyOperationAsync(BacnetAddress address, BacnetObjectId objectId, string requestingSrc, BacnetLifeSafetyOperations operation, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginLifeSafetyOperationRequest(address, objectId, 0, requestingSrc, operation, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed life safety operation {operation} on {objectId} at {address}");
+
+        EndLifeSafetyOperationRequest(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task AlarmAcknowledgementAsync(BacnetAddress adr, BacnetObjectId objId, BacnetEventStates eventState, string ackText, BacnetGenericTime evTimeStamp, BacnetGenericTime ackTimeStamp, byte invokeId = 0, CancellationToken cancellationToken = default)
+    {
+        using var result = (BacnetAsyncResult)BeginAlarmAcknowledgement(adr, objId, eventState, ackText, evTimeStamp, ackTimeStamp, true, invokeId);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to acknowledge alarm on {objId} at {adr}");
+
+        EndAlarmAcknowledgement(result, out var ex);
+        if (ex != null)
+            throw ex;
+    }
+
+    public async Task NotifyAsync(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, bool issueConfirmedNotifications, IList<BacnetPropertyValue> values, CancellationToken cancellationToken = default)
+    {
+        if (!issueConfirmedNotifications)
+        {
+            Notify(adr, subscriberProcessIdentifier, initiatingDeviceIdentifier, monitoredObjectIdentifier, timeRemaining, false, values);
+            return;
+        }
+
+        using var result = (BacnetAsyncResult)BeginConfirmedNotify(adr, subscriberProcessIdentifier, initiatingDeviceIdentifier, monitoredObjectIdentifier, timeRemaining, values, true);
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
+            throw new TimeoutException($"Failed to notify {monitoredObjectIdentifier} on {adr}");
+
+        EndConfirmedNotify(result, out var ex);
+        if (ex != null)
+            throw ex;
     }
 
     public static byte GetSegmentsCount(BacnetMaxSegments maxSegments)

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2791,7 +2791,7 @@ public class BacnetClient : IDisposable
     // ==============================================================================================
 
     /// <summary>
-    /// Writes a block to a File object (AtomicWriteFile) and returns the new file position.
+    /// Write a block to a File object (AtomicWriteFile) and return the new file position.
     /// </summary>
     public async Task<int> WriteFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, int count, byte[] fileBuffer, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2807,7 +2807,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Reads a block from a File object (AtomicReadFile).
+    /// Read a block from a File object (AtomicReadFile).
     /// </summary>
     public async Task<BacnetReadFileResult> ReadFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2824,7 +2824,7 @@ public class BacnetClient : IDisposable
 
     // Read range by start time
     /// <summary>
-    /// Reads a range of items from a list or log property, starting at the given time.
+    /// Read a range of items from a list or log property, starting at the given time.
     /// </summary>
     public async Task<BacnetReadRangeResult> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, DateTime readFrom, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2841,7 +2841,7 @@ public class BacnetClient : IDisposable
 
     // Read range by position
     /// <summary>
-    /// Reads a range of items from a list or log property, starting at the given index.
+    /// Read a range of items from a list or log property, starting at the given index.
     /// </summary>
     public async Task<BacnetReadRangeResult> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, uint idxBegin, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2857,7 +2857,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Subscribes to (or cancels) change-of-value notifications for an object.
+    /// Subscribe to (or cancel) change-of-value notifications for an object.
     /// </summary>
     public async Task SubscribeCOVAsync(BacnetAddress adr, BacnetObjectId objectId, uint subscribeId, bool cancel, bool issueConfirmedNotifications, uint lifetime, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2871,7 +2871,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Sends a confirmed event notification.
+    /// Send a confirmed event notification.
     /// </summary>
     public async Task SendConfirmedEventNotificationAsync(BacnetAddress adr, BacnetEventNotificationData eventData, byte invokeId = 0, BacnetAddress source = null, CancellationToken cancellationToken = default)
     {
@@ -2885,7 +2885,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Subscribes to (or cancels) change-of-value notifications for a single property.
+    /// Subscribe to (or cancel) change-of-value notifications for a single property.
     /// </summary>
     public async Task SubscribePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference monitoredProperty, uint subscribeId, bool cancel, bool issueConfirmedNotifications, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2899,7 +2899,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Writes a single property of an object.
+    /// Write a single property of an object.
     /// </summary>
     public async Task WritePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL, CancellationToken cancellationToken = default)
     {
@@ -2913,7 +2913,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Writes several properties of a single object.
+    /// Write several properties of a single object.
     /// </summary>
     public async Task WritePropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2927,7 +2927,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Writes several properties across several objects.
+    /// Write several properties across several objects.
     /// </summary>
     public async Task WritePropertyMultipleAsync(BacnetAddress adr, ICollection<BacnetReadAccessResult> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2941,7 +2941,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Reads several properties of a single object.
+    /// Read several properties of a single object.
     /// </summary>
     public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2957,7 +2957,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Reads several properties across several objects.
+    /// Read several properties across several objects.
     /// </summary>
     public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, IList<BacnetReadAccessSpecification> properties, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2973,7 +2973,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Creates an object on the remote device.
+    /// Create an object on the remote device.
     /// </summary>
     public async Task CreateObjectAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList = null, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -2987,7 +2987,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Deletes an object on the remote device.
+    /// Delete an object on the remote device.
     /// </summary>
     public async Task DeleteObjectAsync(BacnetAddress adr, BacnetObjectId objectId, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3001,7 +3001,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Adds one or more elements to a list property.
+    /// Add one or more elements to a list property.
     /// </summary>
     public async Task AddListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3015,7 +3015,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Removes one or more elements from a list property.
+    /// Remove one or more elements from a list property.
     /// </summary>
     public async Task RemoveListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3029,7 +3029,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Sends a confirmed request with a caller-supplied, pre-encoded payload and returns the raw response body.
+    /// Send a confirmed request with a caller-supplied, pre-encoded payload and return the raw response body.
     /// </summary>
     public async Task<byte[]> RawEncodedDecodedPropertyConfirmedAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, BacnetConfirmedServices serviceId, byte[] inOutBuffer = null, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3045,7 +3045,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Enables or disables the remote device's BACnet communication.
+    /// Enable or disable the remote device's BACnet communication.
     /// </summary>
     public async Task DeviceCommunicationControlAsync(BacnetAddress adr, uint timeDuration, uint enableDisable, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3059,7 +3059,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Sends a vendor-specific confirmed PrivateTransfer request and returns the device's response.
+    /// Send a vendor-specific confirmed PrivateTransfer request and return the device's response.
     /// </summary>
     public async Task<BacnetPrivateTransferResult> PrivateTransferAsync(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3075,7 +3075,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Reads the device's alarm summary or event information, following the get-next chain to completion.
+    /// Read the device's alarm summary or event information, following the get-next chain to completion.
     /// </summary>
     public async Task<IList<BacnetGetEventInformationData>> GetAlarmSummaryOrEventAsync(BacnetAddress adr, bool getEvent, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3100,7 +3100,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Reinitializes the remote device (e.g. warm or cold start).
+    /// Reinitialize the remote device (e.g. warm or cold start).
     /// </summary>
     public async Task ReinitializeAsync(BacnetAddress adr, BacnetReinitializedStates state, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3114,7 +3114,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Sends a life-safety operation (e.g. silence or reset) for an object.
+    /// Send a life-safety operation (e.g. silence or reset) for an object.
     /// </summary>
     public async Task LifeSafetyOperationAsync(BacnetAddress address, BacnetObjectId objectId, string requestingSrc, BacnetLifeSafetyOperations operation, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3128,7 +3128,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Acknowledges an alarm or event for an object.
+    /// Acknowledge an alarm or event for an object.
     /// </summary>
     public async Task AlarmAcknowledgementAsync(BacnetAddress adr, BacnetObjectId objId, BacnetEventStates eventState, string ackText, BacnetGenericTime evTimeStamp, BacnetGenericTime ackTimeStamp, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
@@ -3142,7 +3142,7 @@ public class BacnetClient : IDisposable
     }
 
     /// <summary>
-    /// Sends a change-of-value notification, confirmed or unconfirmed.
+    /// Send a change-of-value notification, confirmed or unconfirmed.
     /// </summary>
     public async Task NotifyAsync(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, bool issueConfirmedNotifications, IList<BacnetPropertyValue> values, CancellationToken cancellationToken = default)
     {

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2809,7 +2809,7 @@ public class BacnetClient : IDisposable
     /// <summary>
     /// Reads a block from a File object (AtomicReadFile).
     /// </summary>
-    public async Task<(int position, uint count, bool endOfFile, byte[] fileBuffer, int fileBufferOffset)> ReadFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, byte invokeId = 0, CancellationToken cancellationToken = default)
+    public async Task<BacnetReadFileResult> ReadFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadFileRequest(adr, objectId, position, count, true, invokeId);
         if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
@@ -2819,14 +2819,14 @@ public class BacnetClient : IDisposable
         if (ex != null)
             throw ex;
 
-        return (readPosition, readCount, endOfFile, buffer, bufferOffset);
+        return new BacnetReadFileResult(readPosition, readCount, endOfFile, buffer, bufferOffset);
     }
 
     // Read range by start time
     /// <summary>
     /// Reads a range of items from a list or log property, starting at the given time.
     /// </summary>
-    public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, DateTime readFrom, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
+    public async Task<BacnetReadRangeResult> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, DateTime readFrom, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, readFrom, quantity, true, invokeId);
         if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
@@ -2836,14 +2836,14 @@ public class BacnetClient : IDisposable
         if (ex != null)
             throw ex;
 
-        return (range, count);
+        return new BacnetReadRangeResult(range, count);
     }
 
     // Read range by position
     /// <summary>
     /// Reads a range of items from a list or log property, starting at the given index.
     /// </summary>
-    public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, uint idxBegin, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
+    public async Task<BacnetReadRangeResult> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, uint idxBegin, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, idxBegin, quantity, true, invokeId);
         if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
@@ -2853,7 +2853,7 @@ public class BacnetClient : IDisposable
         if (ex != null)
             throw ex;
 
-        return (range, count);
+        return new BacnetReadRangeResult(range, count);
     }
 
     /// <summary>
@@ -3061,7 +3061,7 @@ public class BacnetClient : IDisposable
     /// <summary>
     /// Sends a vendor-specific confirmed PrivateTransfer request and returns the device's response.
     /// </summary>
-    public async Task<(uint vendorId, uint serviceNumber, byte[] resultBlock)> PrivateTransferAsync(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, byte invokeId = 0, CancellationToken cancellationToken = default)
+    public async Task<BacnetPrivateTransferResult> PrivateTransferAsync(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginPrivateTransferRequest(adr, vendorId, serviceNumber, serviceParameters, true, invokeId);
         if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
@@ -3071,7 +3071,7 @@ public class BacnetClient : IDisposable
         if (ex != null)
             throw ex;
 
-        return (outVendorId, outServiceNumber, resultBlock);
+        return new BacnetPrivateTransferResult(outVendorId, outServiceNumber, resultBlock);
     }
 
     /// <summary>

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -1775,17 +1775,17 @@ public class BacnetClient : IDisposable
     }
 
     public Task<IList<BacnetValue>> ReadPropertyAsync(BacnetAddress address, BacnetObjectTypes objType, uint objInstance,
-        BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
+        BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL, CancellationToken cancellationToken = default)
     {
         var objectId = new BacnetObjectId(objType, objInstance);
-        return ReadPropertyAsync(address, objectId, propertyId, invokeId, arrayIndex);
+        return ReadPropertyAsync(address, objectId, propertyId, invokeId, arrayIndex, cancellationToken);
     }
 
     public async Task<IList<BacnetValue>> ReadPropertyAsync(BacnetAddress address, BacnetObjectId objectId,
-        BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
+        BacnetPropertyIds propertyId, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadPropertyRequest(address, objectId, propertyId, true, invokeId, arrayIndex);
-        if (!await SendRequestAsync(result, CancellationToken.None).ConfigureAwait(false))
+        if (!await SendRequestAsync(result, cancellationToken).ConfigureAwait(false))
             throw new Exception($"Failed to read property {propertyId} of {objectId} from {address}");
 
         EndReadPropertyRequest(result, out var valueList, out var ex);
@@ -2514,9 +2514,9 @@ public class BacnetClient : IDisposable
         return false;
     }
 
-    public Task<IList<BacnetGetEventInformationData>> GetEventsAsync(BacnetAddress address, byte invokeId = 0)
+    public Task<IList<BacnetGetEventInformationData>> GetEventsAsync(BacnetAddress address, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
-        return GetAlarmSummaryOrEventAsync(address, true, invokeId);
+        return GetAlarmSummaryOrEventAsync(address, true, invokeId, cancellationToken);
     }
 
     public IAsyncResult BeginGetAlarmSummaryOrEventRequest(BacnetAddress adr, bool getEvent, IList<BacnetGetEventInformationData> alarms, bool waitForTransmit, byte invokeId = 0)

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2822,7 +2822,6 @@ public class BacnetClient : IDisposable
         return new BacnetReadFileResult(readPosition, readCount, endOfFile, buffer, bufferOffset);
     }
 
-    // Read range by start time
     /// <summary>
     /// Read a range of items from a list or log property, starting at the given time.
     /// </summary>
@@ -2839,7 +2838,6 @@ public class BacnetClient : IDisposable
         return new BacnetReadRangeResult(range, count);
     }
 
-    // Read range by position
     /// <summary>
     /// Read a range of items from a list or log property, starting at the given index.
     /// </summary>

--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -2790,6 +2790,9 @@ public class BacnetClient : IDisposable
     // in flight concurrently on a single client without a lock.
     // ==============================================================================================
 
+    /// <summary>
+    /// Writes a block to a File object (AtomicWriteFile) and returns the new file position.
+    /// </summary>
     public async Task<int> WriteFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, int count, byte[] fileBuffer, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginWriteFileRequest(adr, objectId, position, count, fileBuffer, true, invokeId);
@@ -2803,6 +2806,9 @@ public class BacnetClient : IDisposable
         return newPosition;
     }
 
+    /// <summary>
+    /// Reads a block from a File object (AtomicReadFile).
+    /// </summary>
     public async Task<(int position, uint count, bool endOfFile, byte[] fileBuffer, int fileBufferOffset)> ReadFileAsync(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadFileRequest(adr, objectId, position, count, true, invokeId);
@@ -2817,6 +2823,9 @@ public class BacnetClient : IDisposable
     }
 
     // Read range by start time
+    /// <summary>
+    /// Reads a range of items from a list or log property, starting at the given time.
+    /// </summary>
     public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, DateTime readFrom, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, readFrom, quantity, true, invokeId);
@@ -2831,6 +2840,9 @@ public class BacnetClient : IDisposable
     }
 
     // Read range by position
+    /// <summary>
+    /// Reads a range of items from a list or log property, starting at the given index.
+    /// </summary>
     public async Task<(byte[] range, uint count)> ReadRangeAsync(BacnetAddress adr, BacnetObjectId objectId, uint idxBegin, uint quantity, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadRangeRequest(adr, objectId, idxBegin, quantity, true, invokeId);
@@ -2844,6 +2856,9 @@ public class BacnetClient : IDisposable
         return (range, count);
     }
 
+    /// <summary>
+    /// Subscribes to (or cancels) change-of-value notifications for an object.
+    /// </summary>
     public async Task SubscribeCOVAsync(BacnetAddress adr, BacnetObjectId objectId, uint subscribeId, bool cancel, bool issueConfirmedNotifications, uint lifetime, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginSubscribeCOVRequest(adr, objectId, subscribeId, cancel, issueConfirmedNotifications, lifetime, true, invokeId);
@@ -2855,6 +2870,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Sends a confirmed event notification.
+    /// </summary>
     public async Task SendConfirmedEventNotificationAsync(BacnetAddress adr, BacnetEventNotificationData eventData, byte invokeId = 0, BacnetAddress source = null, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginSendConfirmedEventNotificationRequest(adr, eventData, true, invokeId, source);
@@ -2866,6 +2884,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Subscribes to (or cancels) change-of-value notifications for a single property.
+    /// </summary>
     public async Task SubscribePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference monitoredProperty, uint subscribeId, bool cancel, bool issueConfirmedNotifications, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginSubscribePropertyRequest(adr, objectId, monitoredProperty, subscribeId, cancel, issueConfirmedNotifications, true, invokeId);
@@ -2877,6 +2898,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Writes a single property of an object.
+    /// </summary>
     public async Task WritePropertyAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginWritePropertyRequest(adr, objectId, propertyId, valueList, true, invokeId, priority, arrayIndex);
@@ -2888,6 +2912,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Writes several properties of a single object.
+    /// </summary>
     public async Task WritePropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginWritePropertyMultipleRequest(adr, objectId, valueList, true, invokeId);
@@ -2899,6 +2926,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Writes several properties across several objects.
+    /// </summary>
     public async Task WritePropertyMultipleAsync(BacnetAddress adr, ICollection<BacnetReadAccessResult> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginWritePropertyMultipleRequest(adr, valueList, true, invokeId);
@@ -2910,6 +2940,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Reads several properties of a single object.
+    /// </summary>
     public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadPropertyMultipleRequest(adr, objectId, propertyIdAndArrayIndex, true, invokeId);
@@ -2923,6 +2956,9 @@ public class BacnetClient : IDisposable
         return values;
     }
 
+    /// <summary>
+    /// Reads several properties across several objects.
+    /// </summary>
     public async Task<IList<BacnetReadAccessResult>> ReadPropertyMultipleAsync(BacnetAddress adr, IList<BacnetReadAccessSpecification> properties, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReadPropertyMultipleRequest(adr, properties, true, invokeId);
@@ -2936,6 +2972,9 @@ public class BacnetClient : IDisposable
         return values;
     }
 
+    /// <summary>
+    /// Creates an object on the remote device.
+    /// </summary>
     public async Task CreateObjectAsync(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList = null, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginCreateObjectRequest(adr, objectId, valueList, true, invokeId);
@@ -2947,6 +2986,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Deletes an object on the remote device.
+    /// </summary>
     public async Task DeleteObjectAsync(BacnetAddress adr, BacnetObjectId objectId, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginDeleteObjectRequest(adr, objectId, true, invokeId);
@@ -2958,6 +3000,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Adds one or more elements to a list property.
+    /// </summary>
     public async Task AddListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginAddListElementRequest(adr, objectId, reference, valueList, true, invokeId);
@@ -2969,6 +3014,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Removes one or more elements from a list property.
+    /// </summary>
     public async Task RemoveListElementAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginRemoveListElementRequest(adr, objectId, reference, valueList, true, invokeId);
@@ -2980,6 +3028,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Sends a confirmed request with a caller-supplied, pre-encoded payload and returns the raw response body.
+    /// </summary>
     public async Task<byte[]> RawEncodedDecodedPropertyConfirmedAsync(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, BacnetConfirmedServices serviceId, byte[] inOutBuffer = null, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginRawEncodedDecodedPropertyConfirmedRequest(adr, objectId, propertyId, serviceId, inOutBuffer, true, invokeId);
@@ -2993,6 +3044,9 @@ public class BacnetClient : IDisposable
         return outBuffer;
     }
 
+    /// <summary>
+    /// Enables or disables the remote device's BACnet communication.
+    /// </summary>
     public async Task DeviceCommunicationControlAsync(BacnetAddress adr, uint timeDuration, uint enableDisable, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginDeviceCommunicationControlRequest(adr, timeDuration, enableDisable, password, true, invokeId);
@@ -3004,6 +3058,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Sends a vendor-specific confirmed PrivateTransfer request and returns the device's response.
+    /// </summary>
     public async Task<(uint vendorId, uint serviceNumber, byte[] resultBlock)> PrivateTransferAsync(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginPrivateTransferRequest(adr, vendorId, serviceNumber, serviceParameters, true, invokeId);
@@ -3017,6 +3074,9 @@ public class BacnetClient : IDisposable
         return (outVendorId, outServiceNumber, resultBlock);
     }
 
+    /// <summary>
+    /// Reads the device's alarm summary or event information, following the get-next chain to completion.
+    /// </summary>
     public async Task<IList<BacnetGetEventInformationData>> GetAlarmSummaryOrEventAsync(BacnetAddress adr, bool getEvent, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         IList<BacnetGetEventInformationData> alarms = new List<BacnetGetEventInformationData>();
@@ -3039,6 +3099,9 @@ public class BacnetClient : IDisposable
         return alarms;
     }
 
+    /// <summary>
+    /// Reinitializes the remote device (e.g. warm or cold start).
+    /// </summary>
     public async Task ReinitializeAsync(BacnetAddress adr, BacnetReinitializedStates state, string password, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginReinitializeRequest(adr, state, password, true, invokeId);
@@ -3050,6 +3113,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Sends a life-safety operation (e.g. silence or reset) for an object.
+    /// </summary>
     public async Task LifeSafetyOperationAsync(BacnetAddress address, BacnetObjectId objectId, string requestingSrc, BacnetLifeSafetyOperations operation, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginLifeSafetyOperationRequest(address, objectId, 0, requestingSrc, operation, true, invokeId);
@@ -3061,6 +3127,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Acknowledges an alarm or event for an object.
+    /// </summary>
     public async Task AlarmAcknowledgementAsync(BacnetAddress adr, BacnetObjectId objId, BacnetEventStates eventState, string ackText, BacnetGenericTime evTimeStamp, BacnetGenericTime ackTimeStamp, byte invokeId = 0, CancellationToken cancellationToken = default)
     {
         using var result = (BacnetAsyncResult)BeginAlarmAcknowledgement(adr, objId, eventState, ackText, evTimeStamp, ackTimeStamp, true, invokeId);
@@ -3072,6 +3141,9 @@ public class BacnetClient : IDisposable
             throw ex;
     }
 
+    /// <summary>
+    /// Sends a change-of-value notification, confirmed or unconfirmed.
+    /// </summary>
     public async Task NotifyAsync(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, bool issueConfirmedNotifications, IList<BacnetPropertyValue> values, CancellationToken cancellationToken = default)
     {
         if (!issueConfirmedNotifications)

--- a/BacnetAsyncResult.cs
+++ b/BacnetAsyncResult.cs
@@ -21,6 +21,14 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
     private ManualResetEvent _waitHandle;
     private readonly BacnetAddress _address;
 
+    // Non-blocking waiting path used by the *Async request methods. It runs in parallel with the
+    // ManualResetEvent above (which still drives the synchronous WaitForDone), so the public API is
+    // unchanged: both are signalled at the same points. Continuations run asynchronously so a waiter
+    // resuming never executes on — and thus never stalls — the transport's receive thread.
+    private readonly object _asyncLock = new();
+    private TaskCompletionSource<bool> _completionSource = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private bool _done;
+
     public bool Segmented { get; private set; }
     public byte[] Result { get; private set; }
     public object AsyncState { get; set; }
@@ -37,6 +45,7 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
             _error = value;
             CompletedSynchronously = true;
             _waitHandle.Set();
+            MarkDone();
         }
     }
 
@@ -80,6 +89,7 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
 
         Segmented = true;
         _waitHandle.Set();
+        MarkActivity();
     }
 
     private void OnSimpleAck(BacnetClient sender, BacnetAddress adr, BacnetPduTypes type, BacnetConfirmedServices service, byte invokeId, byte[] data, int dataOffset, int dataLength)
@@ -88,6 +98,7 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
             return;
 
         _waitHandle.Set();
+        MarkDone();
     }
 
     private void OnAbort(BacnetClient sender, BacnetAddress adr, BacnetPduTypes type, byte invokeId, BacnetAbortReason reason, byte[] buffer, int offset, int length)
@@ -127,6 +138,7 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
 
         //notify waiter even if segmented
         _waitHandle.Set();
+        MarkDone();
     }
 
     /// <summary>
@@ -142,6 +154,57 @@ public class BacnetAsyncResult : IAsyncResult, IDisposable
                 _waitHandle.Reset();
             else
                 return true;
+        }
+    }
+
+    /// <summary>
+    /// Non-blocking equivalent of <see cref="WaitForDone"/>. Completes when a terminal reply (simple
+    /// ack, final complex ack, error, abort or reject) for this invoke-id arrives, mirroring the
+    /// segmented semantics of <see cref="WaitForDone"/>: each incoming segment re-arms the timeout so
+    /// the whole transfer is bounded per segment, not in total.
+    /// </summary>
+    /// <returns><c>true</c> if the request completed within the timeout; <c>false</c> on timeout.</returns>
+    public async Task<bool> GetResultOrTimeout(int timeoutMs, CancellationToken cancellationToken = default)
+    {
+        while (true)
+        {
+            Task signal;
+            lock (_asyncLock)
+            {
+                if (_done)
+                    return true;
+                if (_completionSource.Task.IsCompleted)
+                    _completionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                signal = _completionSource.Task;
+            }
+
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var completed = await Task.WhenAny(signal, Task.Delay(timeoutMs, timeoutCts.Token)).ConfigureAwait(false);
+
+            if (completed != signal)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return false;
+            }
+
+            // A terminal reply or a segment arrived; stop the timer and loop to re-evaluate: _done
+            // ends the wait, a bare segment re-arms it (the completed source is replaced above).
+            timeoutCts.Cancel();
+        }
+    }
+
+    private void MarkActivity()
+    {
+        lock (_asyncLock)
+            _completionSource.TrySetResult(true);
+    }
+
+    private void MarkDone()
+    {
+        lock (_asyncLock)
+        {
+            _done = true;
+            _completionSource.TrySetResult(true);
         }
     }
 

--- a/Base/BacnetPrivateTransferResult.cs
+++ b/Base/BacnetPrivateTransferResult.cs
@@ -1,0 +1,24 @@
+namespace System.IO.BACnet;
+
+/// <summary>
+/// The result of a confirmed PrivateTransfer request: the vendor and service the device echoed back
+/// and the vendor-specific result payload (ASHRAE 135 §16.2).
+/// </summary>
+public readonly struct BacnetPrivateTransferResult
+{
+    public BacnetPrivateTransferResult(uint vendorId, uint serviceNumber, byte[] resultBlock)
+    {
+        VendorId = vendorId;
+        ServiceNumber = serviceNumber;
+        ResultBlock = resultBlock;
+    }
+
+    /// <summary>The vendor identifier echoed by the device.</summary>
+    public uint VendorId { get; }
+
+    /// <summary>The service number echoed by the device.</summary>
+    public uint ServiceNumber { get; }
+
+    /// <summary>The vendor-specific result payload; may be null when the device returns none.</summary>
+    public byte[] ResultBlock { get; }
+}

--- a/Base/BacnetPrivateTransferResult.cs
+++ b/Base/BacnetPrivateTransferResult.cs
@@ -13,12 +13,18 @@ public readonly struct BacnetPrivateTransferResult
         ResultBlock = resultBlock;
     }
 
-    /// <summary>The vendor identifier echoed by the device.</summary>
+    /// <summary>
+    /// The vendor identifier echoed by the device.
+    /// </summary>
     public uint VendorId { get; }
 
-    /// <summary>The service number echoed by the device.</summary>
+    /// <summary>
+    /// The service number echoed by the device.
+    /// </summary>
     public uint ServiceNumber { get; }
 
-    /// <summary>The vendor-specific result payload; may be null when the device returns none.</summary>
+    /// <summary>
+    /// The vendor-specific result payload; may be null when the device returns none.
+    /// </summary>
     public byte[] ResultBlock { get; }
 }

--- a/Base/BacnetReadFileResult.cs
+++ b/Base/BacnetReadFileResult.cs
@@ -1,0 +1,35 @@
+namespace System.IO.BACnet;
+
+/// <summary>
+/// The result of an AtomicReadFile request: the returned file data together with the position it was
+/// read from and whether the end of the file was reached (ASHRAE 135 §14.1.1).
+/// </summary>
+public readonly struct BacnetReadFileResult
+{
+    public BacnetReadFileResult(int position, uint count, bool endOfFile, byte[] fileBuffer, int fileBufferOffset)
+    {
+        Position = position;
+        Count = count;
+        EndOfFile = endOfFile;
+        FileBuffer = fileBuffer;
+        FileBufferOffset = fileBufferOffset;
+    }
+
+    /// <summary>The file position the data was read from.</summary>
+    public int Position { get; }
+
+    /// <summary>The number of octets returned.</summary>
+    public uint Count { get; }
+
+    /// <summary>Whether the read reached the end of the file.</summary>
+    public bool EndOfFile { get; }
+
+    /// <summary>
+    /// Buffer holding the returned data; read <see cref="Count"/> octets starting at
+    /// <see cref="FileBufferOffset"/>.
+    /// </summary>
+    public byte[] FileBuffer { get; }
+
+    /// <summary>The offset into <see cref="FileBuffer"/> at which the returned data starts.</summary>
+    public int FileBufferOffset { get; }
+}

--- a/Base/BacnetReadFileResult.cs
+++ b/Base/BacnetReadFileResult.cs
@@ -15,13 +15,19 @@ public readonly struct BacnetReadFileResult
         FileBufferOffset = fileBufferOffset;
     }
 
-    /// <summary>The file position the data was read from.</summary>
+    /// <summary>
+    /// The file position the data was read from.
+    /// </summary>
     public int Position { get; }
 
-    /// <summary>The number of octets returned.</summary>
+    /// <summary>
+    /// The number of octets returned.
+    /// </summary>
     public uint Count { get; }
 
-    /// <summary>Whether the read reached the end of the file.</summary>
+    /// <summary>
+    /// Whether the read reached the end of the file.
+    /// </summary>
     public bool EndOfFile { get; }
 
     /// <summary>
@@ -30,6 +36,8 @@ public readonly struct BacnetReadFileResult
     /// </summary>
     public byte[] FileBuffer { get; }
 
-    /// <summary>The offset into <see cref="FileBuffer"/> at which the returned data starts.</summary>
+    /// <summary>
+    /// The offset into <see cref="FileBuffer"/> at which the returned data starts.
+    /// </summary>
     public int FileBufferOffset { get; }
 }

--- a/Base/BacnetReadRangeResult.cs
+++ b/Base/BacnetReadRangeResult.cs
@@ -1,0 +1,20 @@
+namespace System.IO.BACnet;
+
+/// <summary>
+/// The result of a ReadRange request: the encoded application data for the returned items and how
+/// many items were returned (ASHRAE 135 §15.8).
+/// </summary>
+public readonly struct BacnetReadRangeResult
+{
+    public BacnetReadRangeResult(byte[] range, uint itemCount)
+    {
+        Range = range;
+        ItemCount = itemCount;
+    }
+
+    /// <summary>The encoded application data of the returned items.</summary>
+    public byte[] Range { get; }
+
+    /// <summary>The number of items returned (may be fewer than requested).</summary>
+    public uint ItemCount { get; }
+}

--- a/Base/BacnetReadRangeResult.cs
+++ b/Base/BacnetReadRangeResult.cs
@@ -12,9 +12,13 @@ public readonly struct BacnetReadRangeResult
         ItemCount = itemCount;
     }
 
-    /// <summary>The encoded application data of the returned items.</summary>
+    /// <summary>
+    /// The encoded application data of the returned items.
+    /// </summary>
     public byte[] Range { get; }
 
-    /// <summary>The number of items returned (may be fewer than requested).</summary>
+    /// <summary>
+    /// The number of items returned (may be fewer than requested).
+    /// </summary>
     public uint ItemCount { get; }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   `BacnetWeekNDay` give `Weekly_Schedule`, `Exception_Schedule` and `Date_List` symmetric
   encode/decode - values read from a device can be modified and written back as-is
   (ASHRAE 135-2016 clauses 12.9 / 12.24 / 21).
+- Asynchronous, non-blocking client API (#46): every confirmed service has an awaitable `…Async`
+  counterpart (`ReadPropertyAsync`, `WritePropertyAsync`, `SubscribeCOVAsync`, …) that no longer parks
+  a thread per outstanding request, so many requests can be in flight on one client at once, each reply
+  matched to its request by invoke-id. Failures throw (a `TimeoutException` once retries are exhausted,
+  otherwise the device error); most methods accept an optional `CancellationToken`, and the
+  file/range/private-transfer variants return typed results (`BacnetReadFileResult`,
+  `BacnetReadRangeResult`, `BacnetPrivateTransferResult`).
 
 ### Changed
 - The core package is now pure-managed with no native dependencies (closes the pcap → log4net chain, #112).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ or expose your application as a BACnet device.
 
 - **Transports** — BACnet/IP (UDP, IPv4 & IPv6) with BBMD and foreign-device registration; BACnet/Ethernet (pcap); MS/TP and PTP over a serial port
 - **Client and device (server) roles** — send requests and/or answer them from your own object model
+- **Async client API** — every confirmed request also has a non-blocking, awaitable `…Async` counterpart, so many can be in flight on one client at once
 - **Discovery** — Who-Is / I-Am and Who-Has / I-Have, including across routers
 - **Data access** — ReadProperty, WriteProperty, ReadPropertyMultiple, WritePropertyMultiple, ReadRange
 - **Change of Value** — SubscribeCOV / SubscribeProperty and COV notifications
@@ -81,6 +82,34 @@ Console.ReadLine();
 
 The [`Examples/`](https://github.com/ela-compil/BACnet/tree/master/Examples) folder has runnable samples — basic read/write, a device/server,
 COV subscription, alarm/event handling, BBMD, a serial device, and more.
+
+## Asynchronous requests
+
+Every confirmed service has an awaitable `…Async` counterpart (`ReadPropertyAsync`,
+`WritePropertyAsync`, `ReadPropertyMultipleAsync`, `SubscribeCOVAsync`, …). Awaiting a reply doesn't
+block a thread, so many requests can be in flight on a single client at once — each reply is matched
+to its own request:
+
+```csharp
+using System.IO.BACnet;
+
+var client = new BacnetClient(new BacnetIpUdpProtocolTransport(0xBAC0));
+client.Start();
+
+var adr = new BacnetAddress(BacnetAddressTypes.IP, "192.168.1.50");
+
+// A single read
+var values = await client.ReadPropertyAsync(adr,
+    new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 0), BacnetPropertyIds.PROP_PRESENT_VALUE);
+
+// Or many at once, without one thread parked per request
+var reads = Enumerable.Range(0, 50).Select(i => client.ReadPropertyAsync(adr,
+    new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, (uint)i), BacnetPropertyIds.PROP_PRESENT_VALUE));
+var results = await Task.WhenAll(reads);
+```
+
+On failure they throw — a `TimeoutException` once every retry has timed out, or the device-reported
+error otherwise. Most also accept an optional `CancellationToken`.
 
 ## Logging
 

--- a/Tests/BacnetClientAsyncTests.cs
+++ b/Tests/BacnetClientAsyncTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Tests.Support;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// The asynchronous request methods must be genuinely non-blocking and must correlate every reply to
+/// its own request by invoke-id, so that many confirmed requests can be in flight on a single client
+/// at once without one caller receiving another's value (the failure reported in issue #46).
+/// </summary>
+public class BacnetClientAsyncTests
+{
+    private static readonly BacnetAddress Anywhere = new(BacnetAddressTypes.None, 0, null);
+
+    // Answers each ReadProperty by echoing the requested object instance back as the value, so a
+    // reply delivered to the wrong waiter is detectable: the value would not match the instance asked
+    // for. Segmentation is left null - the payload is a single unsigned integer.
+    private static void AnswerWithInstance(BacnetClient sender, BacnetAddress adr, byte invokeId,
+        BacnetObjectId objectId, BacnetPropertyReference property, BacnetMaxSegments maxSegments)
+    {
+        var value = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT, (uint)objectId.instance);
+        sender.ReadPropertyResponse(adr, invokeId, null, objectId, property, new[] { value });
+    }
+
+    [Fact]
+    public async Task ReadPropertyAsync_returns_the_devices_value()
+    {
+        var (clientTransport, deviceTransport) = LoopbackTransport.CreatePair();
+        using var client = new BacnetClient(clientTransport);
+        using var device = new BacnetClient(deviceTransport);
+
+        device.OnReadPropertyRequest += AnswerWithInstance;
+        client.Start();
+        device.Start();
+
+        var values = await client.ReadPropertyAsync(Anywhere,
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 42), BacnetPropertyIds.PROP_PRESENT_VALUE);
+
+        Assert.Equal(42u, Convert.ToUInt32(values.Single().Value));
+    }
+
+    [Fact]
+    public async Task ReadPropertyAsync_throws_the_devices_error()
+    {
+        var (clientTransport, deviceTransport) = LoopbackTransport.CreatePair();
+        using var client = new BacnetClient(clientTransport);
+        using var device = new BacnetClient(deviceTransport);
+
+        device.OnReadPropertyRequest += (sender, adr, invokeId, objectId, property, maxSegments) =>
+            sender.ErrorResponse(adr, BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY, invokeId,
+                BacnetErrorClasses.ERROR_CLASS_PROPERTY, BacnetErrorCodes.ERROR_CODE_UNKNOWN_PROPERTY);
+        client.Start();
+        device.Start();
+
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() => client.ReadPropertyAsync(Anywhere,
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), BacnetPropertyIds.PROP_PRESENT_VALUE));
+
+        Assert.Contains("UNKNOWN_PROPERTY", ex.Message);
+    }
+
+    [Fact]
+    public async Task Concurrent_reads_each_receive_their_own_reply()
+    {
+        // Replies arrive on background threads with jitter, so they complete out of order and many
+        // requests overlap - the conditions under which a byte invoke-id or a shared wait handle would
+        // cross-deliver values.
+        var (clientTransport, deviceTransport) = ConcurrentLoopbackTransport.CreatePair();
+        using var client = new BacnetClient(clientTransport, timeout: 15000, retries: 1);
+        using var device = new BacnetClient(deviceTransport, timeout: 15000, retries: 1);
+
+        device.OnReadPropertyRequest += AnswerWithInstance;
+        client.Start();
+        device.Start();
+
+        // Stay at or below 255 distinct outstanding requests: the invoke-id is a byte, so beyond a
+        // rollover two live requests could legitimately share an id. That ceiling is a separate matter
+        // from the correlation this test covers.
+        const int count = 200;
+        var reads = Enumerable.Range(0, count).Select(async i =>
+        {
+            var values = await client.ReadPropertyAsync(Anywhere,
+                new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, (uint)i), BacnetPropertyIds.PROP_PRESENT_VALUE);
+            return (requested: (uint)i, returned: Convert.ToUInt32(values.Single().Value));
+        });
+
+        foreach (var (requested, returned) in await Task.WhenAll(reads))
+            Assert.Equal(requested, returned);
+    }
+
+    /// <summary>
+    /// Loopback transport that delivers each frame to its peer on a thread-pool thread after a short
+    /// random delay, so requests and replies genuinely overlap and arrive out of order.
+    /// </summary>
+    private sealed class ConcurrentLoopbackTransport : IBacnetTransport
+    {
+        private ConcurrentLoopbackTransport _peer;
+        private readonly Random _random;
+
+        private ConcurrentLoopbackTransport(int seed) => _random = new Random(seed);
+
+        public byte MaxInfoFrames { get; set; } = 0xFF;
+        public int HeaderLength => 0;
+        public int MaxBufferLength => 1500;
+        public BacnetAddressTypes Type => BacnetAddressTypes.None;
+        public BacnetMaxAdpu MaxAdpuLength => BacnetMaxAdpu.MAX_APDU1476;
+
+        public event MessageRecievedHandler MessageRecieved;
+
+        public static (ConcurrentLoopbackTransport, ConcurrentLoopbackTransport) CreatePair()
+        {
+            var a = new ConcurrentLoopbackTransport(1);
+            var b = new ConcurrentLoopbackTransport(2);
+            a._peer = b;
+            b._peer = a;
+            return (a, b);
+        }
+
+        public void Start() { }
+
+        public BacnetAddress GetBroadcastAddress() => new(BacnetAddressTypes.None, 0, null);
+
+        public bool WaitForAllTransmits(int timeout) => true;
+
+        public int Send(byte[] buffer, int offset, int dataLength, BacnetAddress address, bool waitForTransmission, int timeout)
+        {
+            var frame = new byte[dataLength];
+            Array.Copy(buffer, offset, frame, 0, dataLength);
+
+            int delay;
+            lock (_random)
+                delay = _random.Next(0, 15);
+
+            var peer = _peer;
+            _ = Task.Run(async () =>
+            {
+                await Task.Delay(delay);
+                peer.MessageRecieved?.Invoke(peer, frame, 0, frame.Length, new BacnetAddress(BacnetAddressTypes.None, 0, null));
+            });
+
+            return dataLength;
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/Tests/BacnetClientAsyncTests.cs
+++ b/Tests/BacnetClientAsyncTests.cs
@@ -1,9 +1,16 @@
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO.BACnet.Serialize;
 using System.IO.BACnet.Tests.Support;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+
+// These tests drive the library's own timeout/cancellation semantics (and pass an explicit token
+// where cancellation is under test), so they deliberately don't thread xUnit's TestContext token.
+#pragma warning disable xUnit1051
 
 namespace System.IO.BACnet.Tests;
 
@@ -104,6 +111,80 @@ public class BacnetClientAsyncTests
         await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.ReadPropertyAsync(Anywhere,
             new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), BacnetPropertyIds.PROP_PRESENT_VALUE,
             cancellationToken: cts.Token));
+    }
+
+    [Fact]
+    public async Task ReadPropertyAsync_reassembles_a_segmented_response()
+    {
+        // Produce a genuine multi-segment ReadProperty-ACK with the (proven) send path, then feed those
+        // segments to the client under test and confirm the awaited read reassembles them in order.
+        // This exercises the async wait's per-segment re-arm - the path that PR #118's approach lost.
+        var text = MakeCharString(3000);
+        const byte invokeId = 55;
+        var objectId = new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 1234);
+        var property = new BacnetPropertyReference((uint)BacnetPropertyIds.PROP_DESCRIPTION, ASN1.BACNET_ARRAY_ALL);
+        var adr = new BacnetAddress(BacnetAddressTypes.IP, "10.0.0.2:47808");
+        var bigValue = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_CHARACTER_STRING, text);
+
+        var producerTransport = new RecordingTransport(maxApdu: BacnetMaxAdpu.MAX_APDU480) { AutoSegmentAck = true };
+        using var producer = new BacnetClient(producerTransport);
+        producer.Start();
+        var segmentation = producer.GetSegmentBuffer(BacnetMaxSegments.MAX_SEG16, BacnetMaxAdpu.MAX_APDU480);
+        producer.ReadPropertyResponse(adr, invokeId, segmentation, objectId, property, new[] { bigValue });
+
+        // The send path streams the remaining segments on a background thread (driven by AutoSegmentAck),
+        // so wait until the whole sequence has been emitted before harvesting the frames.
+        var segments = WaitForSegments(producerTransport);
+        Assert.True(segments.Count > 1, $"test setup: expected a segmented response, produced {segments.Count} frame(s)");
+
+        var consumerTransport = new RecordingTransport(maxApdu: BacnetMaxAdpu.MAX_APDU480);
+        using var client = new BacnetClient(consumerTransport, timeout: 5000, retries: 1);
+        client.MaxSegments = BacnetMaxSegments.MAX_SEG16;   // advertise that segmented responses are accepted
+        var segmentsSeen = 0;
+        client.OnSegment += (_, _, _, _, _, _, _, _, _, _, _) => Interlocked.Increment(ref segmentsSeen);
+        client.Start();
+
+        var readTask = client.ReadPropertyAsync(adr, objectId,
+            (BacnetPropertyIds)property.propertyIdentifier, invokeId: invokeId);
+
+        foreach (var segment in segments)
+            consumerTransport.Receive(segment, adr);
+
+        var values = await readTask;
+
+        Assert.True(segmentsSeen > 1, $"expected several segments to be received, saw {segmentsSeen}");
+        Assert.Single(values);
+        Assert.Equal(text, values[0].Value);
+    }
+
+    private static string MakeCharString(int length)
+    {
+        var builder = new StringBuilder(length);
+        while (builder.Length < length)
+            builder.Append("0123456789");
+        return builder.ToString(0, length);
+    }
+
+    // Poll a recording transport until it has emitted a complete ComplexACK segment sequence
+    // (the last segment clears MORE_FOLLOWS). The NPDU here is 2 bytes, so the PDU-type octet is [2].
+    private static List<byte[]> WaitForSegments(RecordingTransport transport)
+    {
+        var watch = Stopwatch.StartNew();
+        while (watch.ElapsedMilliseconds < 5000)
+        {
+            List<byte[]> complexAcks;
+            lock (transport.Sent)
+            {
+                complexAcks = transport.Sent
+                    .Select(s => s.Frame)
+                    .Where(f => ((BacnetPduTypes)f[2] & BacnetPduTypes.PDU_TYPE_MASK) == BacnetPduTypes.PDU_TYPE_COMPLEX_ACK)
+                    .ToList();
+            }
+            if (complexAcks.Count > 0 && ((BacnetPduTypes)complexAcks[^1][2] & BacnetPduTypes.MORE_FOLLOWS) == 0)
+                return complexAcks;
+            Thread.Sleep(20);
+        }
+        throw new Exception("segmented response did not complete within 5 s");
     }
 
     /// <summary>

--- a/Tests/BacnetClientAsyncTests.cs
+++ b/Tests/BacnetClientAsyncTests.cs
@@ -91,6 +91,21 @@ public class BacnetClientAsyncTests
             Assert.Equal(requested, returned);
     }
 
+    [Fact]
+    public async Task ReadPropertyAsync_honours_cancellation()
+    {
+        // Nothing ever answers (frames are dropped), so only cancellation can end the wait - and it
+        // must do so long before the 10 s timeout would.
+        using var client = new BacnetClient(new SilentTransport(), timeout: 10000, retries: 1);
+        client.Start();
+
+        using var cts = new CancellationTokenSource(150);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => client.ReadPropertyAsync(Anywhere,
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), BacnetPropertyIds.PROP_PRESENT_VALUE,
+            cancellationToken: cts.Token));
+    }
+
     /// <summary>
     /// Loopback transport that delivers each frame to its peer on a thread-pool thread after a short
     /// random delay, so requests and replies genuinely overlap and arrive out of order.
@@ -143,6 +158,30 @@ public class BacnetClientAsyncTests
 
             return dataLength;
         }
+
+        public void Dispose() { }
+    }
+
+    /// <summary>Transport that accepts sends but never delivers anything back, so requests go unanswered.</summary>
+    private sealed class SilentTransport : IBacnetTransport
+    {
+        public byte MaxInfoFrames { get; set; } = 0xFF;
+        public int HeaderLength => 0;
+        public int MaxBufferLength => 1500;
+        public BacnetAddressTypes Type => BacnetAddressTypes.None;
+        public BacnetMaxAdpu MaxAdpuLength => BacnetMaxAdpu.MAX_APDU1476;
+
+#pragma warning disable CS0067 // required by the interface; this transport never receives
+        public event MessageRecievedHandler MessageRecieved;
+#pragma warning restore CS0067
+
+        public void Start() { }
+
+        public BacnetAddress GetBroadcastAddress() => new(BacnetAddressTypes.None, 0, null);
+
+        public bool WaitForAllTransmits(int timeout) => true;
+
+        public int Send(byte[] buffer, int offset, int dataLength, BacnetAddress address, bool waitForTransmission, int timeout) => dataLength;
 
         public void Dispose() { }
     }

--- a/Tests/BacnetClientAsyncTests.cs
+++ b/Tests/BacnetClientAsyncTests.cs
@@ -162,7 +162,9 @@ public class BacnetClientAsyncTests
         public void Dispose() { }
     }
 
-    /// <summary>Transport that accepts sends but never delivers anything back, so requests go unanswered.</summary>
+    /// <summary>
+    /// Transport that accepts sends but never delivers anything back, so requests go unanswered.
+    /// </summary>
     private sealed class SilentTransport : IBacnetTransport
     {
         public byte MaxInfoFrames { get; set; } = 0xFF;


### PR DESCRIPTION
## Problem

`BacnetClient` has never been safe to use from several threads at once (#46): concurrent
`ReadPropertyRequest` calls could return each other's values, and every outstanding request parked a
thread on a `ManualResetEvent` while it waited for the reply. Wrapping the client in a lock serialised
everything; running one client per thread burned a thread per request.

The **correctness** half is already fixed on this line: invoke-ids are now generated with
`Interlocked.Increment` and each request encodes into its own buffer, so replies are correctly
correlated by invoke-id. What remained was the **blocking** half.

## Approach

This builds on the idea in #118 (thanks to **@YarekTyshchenko** for the original non-blocking prototype)
but applies it **additively**, so nothing in the public API breaks and the segmentation support #118
dropped is kept:

- **`BacnetAsyncResult`** keeps `IAsyncResult`, its `ManualResetEvent`, and every public member. A
  `TaskCompletionSource<bool>` now runs *alongside* the event, signalled at exactly the same points.
  It is created with `RunContinuationsAsynchronously` so a resuming awaiter never runs on — and so
  never stalls — the transport receive thread, and uses `TrySetResult` so a duplicate/late reply can't
  throw. The new `GetResultOrTimeout(int, CancellationToken)` mirrors `WaitForDone`'s per-segment
  timeout re-arm, so segmented transfers behave as before.
- **`BacnetClient`** gains a private non-blocking retry/timeout/resend helper. The three existing
  `*Async` methods (`ReadPropertyAsync`, `ReadPropertyMultipleAsync`, `GetEventsAsync`) now truly await
  instead of `Task.Factory.StartNew(blockingCall)` — **same signatures**, so binary-compatible — and
  `*Async` overloads are added for every remaining confirmed service (write, write-multiple,
  read-multiple, subscribe COV / property, create / delete object, add / remove list element, read /
  write file, read range, private transfer, device communication control, reinitialize, life-safety
  operation, alarm acknowledgement, confirmed notify, get-alarm/event, raw confirmed request), each
  reusing the existing `End*` decoders and taking an optional `CancellationToken`.

Failure is reported by throwing — a `TimeoutException` when every attempt times out, or the
device-reported exception (abort / reject / error / decode failure) otherwise.

## Tests

`Tests/BacnetClientAsyncTests.cs`:
- **200 concurrent reads** with replies delivered out of order on background threads; each caller must
  receive the value matching its own request — this fails if invoke-id correlation or the wait handle
  cross-delivers (the exact #46 symptom).
- Value round-trip and device-error round-trip (the async error path).

Full suite green (304/304) on the `v4` base; library builds on `net48;netstandard2.0;net8.0;net10.0`.

## Compatibility

Source-compatible: all existing call sites compile unchanged. Most of this is purely additive — new
methods/overloads and new members on the already-public `BacnetAsyncResult`; the synchronous
`Begin*`/`End*`/`*Request` path is untouched.

The one caveat is `ReadPropertyAsync` and `GetEventsAsync`, which gained an optional-last
`CancellationToken`. Adding a parameter is source-compatible but not binary-compatible, so a consumer
that swaps in the new assembly without recompiling would need a rebuild. This matches how the project
already treats optional-parameter additions (e.g. #214, `new: optional array index on WriteProperty
requests`), so it is tagged `new:`, not `new!:`.

## Verification

- 306 unit tests pass on `net48;netstandard2.0;net8.0;net10.0`, including concurrent-correlation,
  cancellation, device-error, and **segmented-response reassembly** on the async path.
- Validated end-to-end against a containerised BACpypes3 (third-party) device: 300 reads with up to
  100 in flight and zero cross-delivery, plus a 7-segment `object-list` reassembled both singly and
  across 25 concurrent segmented reads.
- `CancellationToken` is an optional last argument on the async methods (the two
  `ReadPropertyMultipleAsync(..., params BacnetPropertyIds[])` overloads can't take one - C# forbids a
  parameter after `params`; the cancellable read-multiple path is the `IList<BacnetPropertyReference>`
  overload). README + CHANGELOG updated.

Closes #46
Closes #118
