### PR TITLE
test: port Annex F decode coverage from #25 (fixes CreateObject-by-type decode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 - SharpPcap bumped 4.x → 6.x in `BACnet.Ethernet` (drops the vulnerable transitive log4net).
 
 ### Fixed
+- `Services.DecodeCreateObject` now decodes the CreateObject "by object type" request form
+  (objectSpecifier choice `[0]`, where the device assigns the instance number) as well as the
+  "by object identifier" form (`[1]`). Only `[1]` was decoded before, so a request produced by the
+  `EncodeCreateObject(BacnetObjectTypes, ...)` overload could not be read back by a receiver.
 - Segmented responses no longer crash with an `IndexOutOfRangeException` when the APDU limit exceeds
   the transport payload buffer (the default `maxPayload: 1472` vs the 1476-byte B/IP APDU): the segment
   encoder clamps its window to the physical buffer and `EncodeBuffer` reports `NotEnoughBuffer` instead

--- a/Serialize/Services.cs
+++ b/Serialize/Services.cs
@@ -2441,13 +2441,22 @@ public class Services
         objectId = new BacnetObjectId();
         valuesRefs = null;
 
-        //object id
+        //object specifier - a choice of [0] object-type (the device assigns the instance) or
+        //[1] object-identifier; both forms are produced by the two EncodeCreateObject overloads
         len += ASN1.decode_tag_number_and_value(buffer, offset + len, out var tagNumber, out var lenValue);
 
         if (tagNumber == 0 && apduLen > len)
         {
             apduLen -= len;
-            if (apduLen >= 4)
+            ASN1.decode_tag_number(buffer, offset + len, out var choiceTag);
+            if (choiceTag == 0)
+            {
+                len += ASN1.decode_tag_number_and_value(buffer, offset + len, out _, out var typeLen);
+                len += ASN1.decode_enumerated(buffer, offset + len, typeLen, out var objectType);
+                objectId.type = (BacnetObjectTypes)objectType;
+                objectId.instance = ASN1.BACNET_MAX_INSTANCE;
+            }
+            else if (choiceTag == 1 && apduLen >= 4)
             {
                 len += ASN1.decode_context_object_id(buffer, offset + len, 1, out var typenr, out objectId.instance);
                 objectId.type = (BacnetObjectTypes)typenr;
@@ -2459,7 +2468,7 @@ public class Services
             return -1;
         if (ASN1.decode_is_closing_tag(buffer, offset + len))
             len++;
-        //end objectid
+        //end object specifier
 
         // No initial values ?
         if (buffer.Length == offset + len)

--- a/Tests/Base/BacnetBitStringTests.cs
+++ b/Tests/Base/BacnetBitStringTests.cs
@@ -33,4 +33,68 @@ public class BacnetBitStringTests
         // BACnetStatusFlags is a fixed 4-bit string regardless of which bits are set.
         Assert.Equal(4, BacnetBitString.ConvertFromInt(value, 4).bits_used);
     }
+
+    [Fact]
+    public void SetBit_then_GetBit_reads_back_every_bit()
+    {
+        for (byte i = 0; i < 32; i++)
+        {
+            var bitString = new BacnetBitString();
+            bitString.SetBit(i, true);
+            Assert.True(bitString.GetBit(i));
+        }
+    }
+
+    [Fact]
+    public void SetBit_grows_bits_used_to_one_past_the_highest_bit()
+    {
+        for (byte i = 0; i < 32; i++)
+        {
+            var bitString = new BacnetBitString();
+            bitString.SetBit(i, true);
+            Assert.Equal(i + 1, bitString.bits_used);
+        }
+    }
+
+    [Fact]
+    public void SetBit_to_false_still_extends_the_string()
+    {
+        // Clearing a bit that was never set still marks the string as that wide.
+        var bitString = new BacnetBitString();
+        bitString.SetBit(2, false);
+        Assert.Equal(3, bitString.bits_used);
+    }
+
+    [Fact]
+    public void ConvertToInt_reads_back_a_single_set_bit()
+    {
+        for (byte i = 0; i < 32; i++)
+        {
+            var bitString = new BacnetBitString();
+            bitString.SetBit(i, true);
+            Assert.Equal(1u << i, bitString.ConvertToInt());
+        }
+    }
+
+    [Theory]
+    [InlineData(0u)]
+    [InlineData(1u)]
+    [InlineData(0b0000_1000u)]
+    [InlineData(0b0101_0111_0010_0110u)]
+    [InlineData(0x40000000u)]
+    [InlineData(uint.MaxValue)]
+    public void ConvertFromInt_then_ConvertToInt_round_trips(uint value)
+    {
+        Assert.Equal(value, BacnetBitString.ConvertFromInt(value).ConvertToInt());
+    }
+
+    [Fact]
+    public void ConvertFromInt_sets_the_bit_for_each_power_of_two()
+    {
+        for (byte i = 0; i < 32; i++)
+        {
+            var bitString = BacnetBitString.ConvertFromInt(1u << i);
+            Assert.True(bitString.GetBit(i));
+        }
+    }
 }

--- a/Tests/Serialize/AshraeAnnexF2Tests.cs
+++ b/Tests/Serialize/AshraeAnnexF2Tests.cs
@@ -7,7 +7,8 @@ namespace System.IO.BACnet.Tests;
 
 /// <summary>
 /// Golden-vector encode tests from ASHRAE 135 Annex F.2, AtomicReadFile / AtomicWriteFile
-/// (stream and record access). Harvested from #25 (DarkStarDS9), adapted to the v4 API.
+/// (stream and record access), plus encode/decode round-trips that exercise the matching
+/// decoders. Harvested from #25 (DarkStarDS9), adapted to the v4 API.
 /// </summary>
 public class AshraeAnnexF2Tests
 {
@@ -108,5 +109,54 @@ public class AshraeAnnexF2Tests
         Services.EncodeAtomicWriteFileAcknowledge(buffer, false, 14);
 
         Assert.Equal(new byte[] { 0x30, 0x55, 0x07, 0x19, 0x0E }, buffer.ToArray());
+    }
+
+    [Fact] // F.2.1 - AtomicReadFile stream ack decodes back to the encoded file data
+    public void F_2_1_AtomicReadFile_stream_ack_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeAtomicReadFileAcknowledge(buffer, true, false, 0, 1, Stream, Counts(Stream));
+
+        Services.DecodeAtomicReadFileAcknowledge(buffer.buffer, 0, buffer.GetLength(),
+            out var endOfFile, out var isStream, out var position, out var count, out var targetBuffer, out var targetOffset);
+
+        Assert.True(isStream);
+        Assert.False(endOfFile);
+        Assert.Equal(0, position);
+        Assert.Equal((uint)Stream[0].Length, count);
+        Assert.Equal(Stream[0], targetBuffer.Skip(targetOffset).Take((int)count).ToArray());
+    }
+
+    [Fact] // F.2.2 - AtomicWriteFile stream request decodes back to the encoded block
+    public void F_2_2_AtomicWriteFile_stream_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeAtomicWriteFile(buffer, true, File1, 30, 1, Stream, Counts(Stream));
+
+        Services.DecodeAtomicWriteFile(buffer.buffer, 0, buffer.GetLength(),
+            out var isStream, out var objectId, out var position, out var blockCount, out var blocks, out _);
+
+        Assert.True(isStream);
+        Assert.Equal(File1, objectId);
+        Assert.Equal(30, position);
+        Assert.Equal(1u, blockCount);
+        Assert.Equal(Stream[0], blocks[0]);
+    }
+
+    [Fact] // F.2.2 - AtomicWriteFile record request decodes back to the two encoded records
+    public void F_2_2_AtomicWriteFile_record_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeAtomicWriteFile(buffer, false, File2, -1, 2, Records, Counts(Records));
+
+        Services.DecodeAtomicWriteFile(buffer.buffer, 0, buffer.GetLength(),
+            out var isStream, out var objectId, out var position, out var blockCount, out var blocks, out _);
+
+        Assert.False(isStream);
+        Assert.Equal(File2, objectId);
+        Assert.Equal(-1, position);
+        Assert.Equal(2u, blockCount);
+        Assert.Equal(Records[0], blocks[0]);
+        Assert.Equal(Records[1], blocks[1]);
     }
 }

--- a/Tests/Serialize/AshraeAnnexF3Tests.cs
+++ b/Tests/Serialize/AshraeAnnexF3Tests.cs
@@ -7,12 +7,14 @@ namespace System.IO.BACnet.Tests;
 
 /// <summary>
 /// Golden-vector encode tests from ASHRAE 135 Annex F, "Examples of APDU Encoding" — object access
-/// (F.3) and file access (F.2). Vectors harvested from #25 (DarkStarDS9), adapted to the v4 API.
+/// (F.3) and file access (F.2) — plus encode/decode round-trips that exercise the matching decoders.
+/// Vectors harvested from #25 (DarkStarDS9), adapted to the v4 API.
 /// </summary>
 public class AshraeAnnexF3Tests
 {
     private static readonly BacnetObjectId Ai5 = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 5);
     private static readonly BacnetObjectId Ai16 = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 16);
+    private static readonly BacnetAddress Adr = new BacnetAddress(BacnetAddressTypes.None, 0, null);
     private const uint PresentValue = (uint)BacnetPropertyIds.PROP_PRESENT_VALUE;
     private const uint Reliability = (uint)BacnetPropertyIds.PROP_RELIABILITY;
     private const uint Description = (uint)BacnetPropertyIds.PROP_DESCRIPTION;
@@ -412,5 +414,177 @@ public class AshraeAnnexF3Tests
             0x1F, 0x2A, 0x04, 0x00, 0x0E, 0xA4, 0x62, 0x03, 0x17, 0x01, 0xB4, 0x13, 0x38, 0x1B, 0x00, 0x0F, 0x1E,
             0x2C, 0x41, 0x90, 0xCC, 0xCD, 0x1F, 0x2A, 0x04, 0x00, 0x5F, 0x6B, 0x01, 0x35, 0x61
         }, buffer.ToArray());
+    }
+
+    [Fact] // F.3.3 - CreateObject request decodes back to the object type and initial values
+    public void F_3_3_CreateObject_request_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeCreateObject(buffer, BacnetObjectTypes.OBJECT_FILE, new List<BacnetPropertyValue>
+        {
+            new BacnetPropertyValue
+            {
+                property = new BacnetPropertyReference(BacnetPropertyIds.PROP_OBJECT_NAME),
+                value = new List<BacnetValue> { new BacnetValue("Trend 1") }
+            },
+            new BacnetPropertyValue
+            {
+                property = new BacnetPropertyReference(BacnetPropertyIds.PROP_FILE_ACCESS_METHOD),
+                value = new List<BacnetValue>
+                {
+                    new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_ENUMERATED,
+                        (uint)BacnetFileAccessMethod.RECORD_ACCESS)
+                }
+            }
+        });
+
+        Services.DecodeCreateObject(Adr, buffer.buffer, 0, buffer.GetLength(), out var objectId, out var values);
+
+        // The object-type choice leaves the instance for the device to assign (decoded as "unspecified").
+        Assert.Equal(BacnetObjectTypes.OBJECT_FILE, objectId.type);
+        Assert.Equal((uint)ASN1.BACNET_MAX_INSTANCE, objectId.instance);
+        var valueList = values.ToList();
+        Assert.Equal(2, valueList.Count);
+        Assert.Equal((uint)BacnetPropertyIds.PROP_OBJECT_NAME, valueList[0].property.propertyIdentifier);
+        Assert.Equal("Trend 1", valueList[0].value.Single().Value);
+        Assert.Equal((uint)BacnetPropertyIds.PROP_FILE_ACCESS_METHOD, valueList[1].property.propertyIdentifier);
+    }
+
+    [Fact] // CreateObject by object-identifier decodes back to the exact object id (the other objectSpecifier choice)
+    public void CreateObject_by_object_identifier_round_trips()
+    {
+        var target = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 42);
+        var buffer = new EncodeBuffer();
+        Services.EncodeCreateObject(buffer, target, new List<BacnetPropertyValue>
+        {
+            new BacnetPropertyValue
+            {
+                property = new BacnetPropertyReference(BacnetPropertyIds.PROP_OBJECT_NAME),
+                value = new List<BacnetValue> { new BacnetValue("AV 42") }
+            }
+        });
+
+        Services.DecodeCreateObject(Adr, buffer.buffer, 0, buffer.GetLength(), out var objectId, out var values);
+
+        Assert.Equal(target, objectId);
+        Assert.Equal("AV 42", values.Single().value.Single().Value);
+    }
+
+    [Fact] // F.3.4 - DeleteObject request decodes back to the target object id
+    public void F_3_4_DeleteObject_request_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeDeleteObject(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_GROUP, 6));
+
+        Services.DecodeDeleteObject(buffer.buffer, 0, buffer.GetLength(), out var objectId);
+
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_GROUP, 6), objectId);
+    }
+
+    [Fact] // F.3.7 - ReadPropertyMultiple request (single object) decodes back to the specification
+    public void F_3_7_ReadPropertyMultiple_request_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeReadPropertyMultiple(buffer, Ai16, new List<BacnetPropertyReference>
+        {
+            new BacnetPropertyReference(PresentValue, ASN1.BACNET_ARRAY_ALL),
+            new BacnetPropertyReference(Reliability, ASN1.BACNET_ARRAY_ALL)
+        });
+
+        Services.DecodeReadPropertyMultiple(buffer.buffer, 0, buffer.GetLength(), out var properties);
+
+        Assert.Single(properties);
+        Assert.Equal(Ai16, properties[0].objectIdentifier);
+        Assert.Equal(new[] { PresentValue, Reliability },
+            properties[0].propertyReferences.Select(p => p.propertyIdentifier).ToArray());
+    }
+
+    [Fact] // F.3.7 - ReadPropertyMultiple request (multiple objects) decodes back to all specifications
+    public void F_3_7_ReadPropertyMultiple_multipleObjects_request_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeReadPropertyMultiple(buffer, new List<BacnetReadAccessSpecification> { PvSpec(33), PvSpec(50), PvSpec(35) });
+
+        Services.DecodeReadPropertyMultiple(buffer.buffer, 0, buffer.GetLength(), out var properties);
+
+        Assert.Equal(3, properties.Count);
+        Assert.Equal(new uint[] { 33, 50, 35 }, properties.Select(p => p.objectIdentifier.instance).ToArray());
+        Assert.All(properties, p => Assert.Equal(PresentValue, p.propertyReferences.Single().propertyIdentifier));
+    }
+
+    [Fact] // F.3.7 - ReadPropertyMultiple ack decodes back to the read-access results
+    public void F_3_7_ReadPropertyMultiple_ack_round_trips()
+    {
+        var results = new List<BacnetReadAccessResult>
+        {
+            new BacnetReadAccessResult(Ai16, new List<BacnetPropertyValue>
+            {
+                new BacnetPropertyValue
+                {
+                    property = new BacnetPropertyReference(PresentValue, ASN1.BACNET_ARRAY_ALL),
+                    value = new List<BacnetValue> { new BacnetValue(72.3f) }
+                },
+                new BacnetPropertyValue
+                {
+                    property = new BacnetPropertyReference(Reliability, ASN1.BACNET_ARRAY_ALL),
+                    value = new List<BacnetValue>
+                    {
+                        new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_ENUMERATED,
+                            (uint)BacnetReliability.RELIABILITY_NO_FAULT_DETECTED)
+                    }
+                }
+            })
+        };
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeReadPropertyMultipleAcknowledge(buffer, results);
+
+        Services.DecodeReadPropertyMultipleAcknowledge(Adr, buffer.buffer, 0, buffer.GetLength(), out var values);
+
+        Assert.Single(values);
+        Assert.Equal(Ai16, values[0].objectIdentifier);
+        var props = values[0].values.ToList();
+        Assert.Equal(2, props.Count);
+        Assert.Equal(PresentValue, props[0].property.propertyIdentifier);
+        Assert.Equal(72.3f, Convert.ToSingle(props[0].value.Single().Value));
+        Assert.Equal(Reliability, props[1].property.propertyIdentifier);
+    }
+
+    [Fact] // F.3.8 - a trend-log record (timestamp + REAL value + status) survives an encode/decode round-trip
+    public void F_3_8_LogRecord_round_trips()
+    {
+        // DecodeLogRecord's nCurves is the number of values in one (TrendLogMultiple) record, all sharing
+        // the single timestamp - not a count of independent records - so this decodes one single-curve record.
+        var record = new BacnetLogRecord(BacnetTrendLogValueType.TL_TYPE_REAL, 18.1f,
+            new DateTime(1998, 3, 23, 19, 56, 27), BacnetStatusFlags.STATUS_FLAG_IN_ALARM);
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeLogRecord(buffer, record);
+
+        Services.DecodeLogRecord(buffer.buffer, 0, buffer.GetLength(), 1, out var records);
+
+        Assert.Single(records);
+        Assert.Equal(record.timestamp, records[0].timestamp);
+        Assert.Equal(18.1f, Convert.ToSingle(records[0].Value));
+        Assert.Equal(record.statusFlags, records[0].statusFlags);
+    }
+
+    [Theory] // A ReadProperty ack with a corrupted tag octet must be rejected, not silently mis-decoded.
+    [InlineData(0)]  // object-id context tag [0]
+    [InlineData(5)]  // property-id context tag [1]
+    [InlineData(7)]  // opening tag [3] of the value
+    [InlineData(13)] // closing tag [3] of the value
+    public void ReadProperty_ack_with_a_corrupted_tag_is_rejected(int corruptedByte)
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeReadPropertyAcknowledge(buffer, Ai5, PresentValue, ASN1.BACNET_ARRAY_ALL,
+            new List<BacnetValue> { new BacnetValue(72.3f) });
+        var bytes = buffer.ToArray();
+        unchecked { bytes[corruptedByte] += 128; }
+
+        var consumed = Services.DecodeReadPropertyAcknowledge(Adr, bytes, 0, bytes.Length,
+            out _, out _, out _);
+
+        Assert.Equal(-1, consumed);
     }
 }

--- a/Tests/Serialize/AshraeAnnexFTests.cs
+++ b/Tests/Serialize/AshraeAnnexFTests.cs
@@ -1,17 +1,21 @@
 using System.Collections.Generic;
 using System.IO.BACnet.Serialize;
+using System.Linq;
 using Xunit;
 
 namespace System.IO.BACnet.Tests;
 
 /// <summary>
 /// Golden-vector encode tests from ASHRAE 135 Annex F, "Examples of APDU Encoding" — alarm/event
-/// (F.1) and remote-device management (F.4). Vectors harvested from the community test effort in
-/// #25 (DarkStarDS9) and adapted to the v4 API / xUnit. The F.1 alarm/event examples are expressed
-/// against the flat BacnetEventNotificationData / COV API (not #25's refactored event model).
+/// (F.1) and remote-device management (F.4) — plus encode/decode round-trips that exercise the
+/// matching decoders. Vectors harvested from the community test effort in #25 (DarkStarDS9) and
+/// adapted to the v4 API / xUnit. The F.1 alarm/event examples are expressed against the flat
+/// BacnetEventNotificationData / COV API (not #25's refactored event model).
 /// </summary>
 public class AshraeAnnexFTests
 {
+    private static readonly BacnetAddress Adr = new BacnetAddress(BacnetAddressTypes.None, 0, null);
+
     // AnalogInput#10 Present_Value = 65.0, Status_Flags = {false,false,false,false}
     private static BacnetPropertyValue[] CovValues() => new[]
     {
@@ -518,5 +522,262 @@ public class AshraeAnnexFTests
         {
             0x00, 0x02, 0x0F, 0x1B, 0x09, 0x12, 0x1C, 0x00, 0x4D, 0x44, 0x4C, 0x29, 0x04, 0x3C, 0x05, 0x40, 0x00, 0x01
         }, buffer.ToArray());
+    }
+
+    [Fact] // F.1.3 - UnconfirmedCOVNotification decodes back to the monitored object and property values
+    public void F_1_3_UnconfirmedCOVNotification_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeCOVNotifyUnconfirmed(buffer, 18, 4,
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), 0, CovValues());
+
+        Services.DecodeCOVNotifyUnconfirmed(Adr, buffer.buffer, 0, buffer.GetLength(),
+            out var subscriberProcessIdentifier, out var initiatingDevice, out var monitoredObject, out var timeRemaining, out var values);
+
+        Assert.Equal(18u, subscriberProcessIdentifier);
+        Assert.Equal(4u, initiatingDevice.instance);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), monitoredObject);
+        Assert.Equal(0u, timeRemaining);
+        Assert.Equal(2, values.Count);
+    }
+
+    [Fact] // F.1.4 - ConfirmedEventNotification (OutOfRange) decodes back to the notification data
+    public void F_1_4_ConfirmedEventNotification_round_trips()
+    {
+        var data = new BacnetEventNotificationData
+        {
+            processIdentifier = 1,
+            initiatingObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_DEVICE, 4),
+            eventObjectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 2),
+            timeStamp = new BacnetGenericTime(default(DateTime), BacnetTimestampTags.TIME_STAMP_SEQUENCE, 16),
+            notificationClass = 4,
+            priority = 100,
+            eventType = BacnetEventTypes.EVENT_OUT_OF_RANGE,
+            notifyType = BacnetNotifyTypes.NOTIFY_ALARM,
+            ackRequired = true,
+            fromState = BacnetEventStates.EVENT_STATE_NORMAL,
+            toState = BacnetEventStates.EVENT_STATE_HIGH_LIMIT,
+            outOfRange_exceedingValue = 80.1f,
+            outOfRange_statusFlags = BacnetBitString.Parse("1000"),
+            outOfRange_deadband = 1.0f,
+            outOfRange_exceededLimit = 80.0f,
+        };
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeEventNotifyConfirmed(buffer, data);
+
+        Services.DecodeEventNotifyData(buffer.buffer, 0, buffer.GetLength(), out var decoded);
+
+        Assert.Equal(data.processIdentifier, decoded.processIdentifier);
+        Assert.Equal(data.initiatingObjectIdentifier, decoded.initiatingObjectIdentifier);
+        Assert.Equal(data.eventObjectIdentifier, decoded.eventObjectIdentifier);
+        Assert.Equal(data.eventType, decoded.eventType);
+        Assert.Equal(data.notifyType, decoded.notifyType);
+        Assert.Equal(data.fromState, decoded.fromState);
+        Assert.Equal(data.toState, decoded.toState);
+        Assert.Equal(data.outOfRange_exceedingValue, decoded.outOfRange_exceedingValue);
+        Assert.Equal(data.outOfRange_exceededLimit, decoded.outOfRange_exceededLimit);
+    }
+
+    [Fact] // F.1.6 - GetAlarmSummary ack decodes back to the two alarm summaries
+    public void F_1_6_GetAlarmSummary_ack_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeAlarmSummary(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 2),
+            (uint)BacnetEventStates.EVENT_STATE_HIGH_LIMIT, BacnetBitString.Parse("011"));
+        Services.EncodeAlarmSummary(buffer, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 3),
+            (uint)BacnetEventStates.EVENT_STATE_LOW_LIMIT, BacnetBitString.Parse("111"));
+
+        IList<BacnetGetEventInformationData> alarms = new List<BacnetGetEventInformationData>();
+        Services.DecodeAlarmSummaryOrEvent(buffer.buffer, 0, buffer.GetLength(), false, ref alarms, out var moreEvent);
+
+        Assert.False(moreEvent);
+        Assert.Equal(2, alarms.Count);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 2), alarms[0].objectIdentifier);
+        Assert.Equal(BacnetEventStates.EVENT_STATE_HIGH_LIMIT, alarms[0].eventState);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 3), alarms[1].objectIdentifier);
+        Assert.Equal(BacnetEventStates.EVENT_STATE_LOW_LIMIT, alarms[1].eventState);
+    }
+
+    [Fact] // F.1.8 - GetEventInformation ack decodes back to the two events
+    public void F_1_8_GetEventInformation_ack_round_trips()
+    {
+        var events = new[]
+        {
+            new BacnetGetEventInformationData
+            {
+                objectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 2),
+                eventState = BacnetEventStates.EVENT_STATE_HIGH_LIMIT,
+                acknowledgedTransitions = BacnetBitString.Parse("011"),
+                eventTimeStamps = new[]
+                {
+                    new BacnetGenericTime(new DateTime(1, 1, 1, 15, 35, 0).AddMilliseconds(200), BacnetTimestampTags.TIME_STAMP_TIME),
+                    new BacnetGenericTime(ASN1.BACNET_TIME_WILDCARD, BacnetTimestampTags.TIME_STAMP_TIME),
+                    new BacnetGenericTime(ASN1.BACNET_TIME_WILDCARD, BacnetTimestampTags.TIME_STAMP_TIME),
+                },
+                notifyType = BacnetNotifyTypes.NOTIFY_ALARM,
+                eventEnable = BacnetBitString.Parse("111"),
+                eventPriorities = new uint[] { 15, 15, 20 }
+            },
+            new BacnetGetEventInformationData
+            {
+                objectIdentifier = new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 3),
+                eventState = BacnetEventStates.EVENT_STATE_NORMAL,
+                acknowledgedTransitions = BacnetBitString.Parse("110"),
+                eventTimeStamps = new[]
+                {
+                    new BacnetGenericTime(new DateTime(1, 1, 1, 15, 40, 0), BacnetTimestampTags.TIME_STAMP_TIME),
+                    new BacnetGenericTime(ASN1.BACNET_TIME_WILDCARD, BacnetTimestampTags.TIME_STAMP_TIME),
+                    new BacnetGenericTime(new DateTime(1, 1, 1, 15, 45, 30).AddMilliseconds(300), BacnetTimestampTags.TIME_STAMP_TIME),
+                },
+                notifyType = BacnetNotifyTypes.NOTIFY_ALARM,
+                eventEnable = BacnetBitString.Parse("111"),
+                eventPriorities = new uint[] { 15, 15, 20 }
+            }
+        };
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeGetEventInformationAcknowledge(buffer, events, false);
+
+        IList<BacnetGetEventInformationData> decoded = new List<BacnetGetEventInformationData>();
+        Services.DecodeAlarmSummaryOrEvent(buffer.buffer, 0, buffer.GetLength(), true, ref decoded, out var moreEvent);
+
+        Assert.False(moreEvent);
+        Assert.Equal(2, decoded.Count);
+        Assert.Equal(events[0].objectIdentifier, decoded[0].objectIdentifier);
+        Assert.Equal(events[0].eventState, decoded[0].eventState);
+        Assert.Equal(events[0].notifyType, decoded[0].notifyType);
+        Assert.Equal(events[1].objectIdentifier, decoded[1].objectIdentifier);
+        Assert.Equal(events[1].eventState, decoded[1].eventState);
+    }
+
+    [Fact] // F.1.10 - SubscribeCOV request decodes back to the subscription parameters
+    public void F_1_10_SubscribeCOV_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeSubscribeCOV(buffer, 18, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), false, true, 0);
+
+        Services.DecodeSubscribeCOV(buffer.buffer, 0, buffer.GetLength(),
+            out var subscriberProcessIdentifier, out var monitoredObject, out var cancellationRequest,
+            out var issueConfirmedNotifications, out var lifetime);
+
+        Assert.Equal(18u, subscriberProcessIdentifier);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), monitoredObject);
+        Assert.False(cancellationRequest);
+        Assert.True(issueConfirmedNotifications);
+        Assert.Equal(0u, lifetime);
+    }
+
+    [Fact] // F.1.11 - SubscribeCOVProperty request decodes back to the property subscription parameters
+    public void F_1_11_SubscribeCOVProperty_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeSubscribeProperty(buffer, 18, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), false, true, 60,
+            new BacnetPropertyReference((uint)BacnetPropertyIds.PROP_PRESENT_VALUE, ASN1.BACNET_ARRAY_ALL), true, 1.0f);
+
+        Services.DecodeSubscribeProperty(buffer.buffer, 0, buffer.GetLength(),
+            out var subscriberProcessIdentifier, out var monitoredObject, out var monitoredProperty,
+            out var cancellationRequest, out var issueConfirmedNotifications, out var lifetime, out var covIncrement);
+
+        Assert.Equal(18u, subscriberProcessIdentifier);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 10), monitoredObject);
+        Assert.Equal((uint)BacnetPropertyIds.PROP_PRESENT_VALUE, monitoredProperty.propertyIdentifier);
+        Assert.False(cancellationRequest);
+        Assert.True(issueConfirmedNotifications);
+        Assert.Equal(60u, lifetime);
+        Assert.Equal(1.0f, covIncrement);
+    }
+
+    [Fact] // F.4.1 - DeviceCommunicationControl request decodes back to its parameters
+    public void F_4_1_DeviceCommunicationControl_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeDeviceCommunicationControl(buffer, 5, 1 /* disable */, "#egbdf!");
+
+        Services.DecodeDeviceCommunicationControl(buffer.buffer, 0, buffer.GetLength(),
+            out var timeDuration, out var enableDisable, out var password);
+
+        Assert.Equal(5u, timeDuration);
+        Assert.Equal(1u, enableDisable);
+        Assert.Equal("#egbdf!", password);
+    }
+
+    [Fact] // F.4.4 - ReinitializeDevice request decodes back to the state and password
+    public void F_4_4_ReinitializeDevice_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeReinitializeDevice(buffer, BacnetReinitializedStates.BACNET_REINIT_WARMSTART, "AbCdEfGh");
+
+        Services.DecodeReinitializeDevice(buffer.buffer, 0, buffer.GetLength(), out var state, out var password);
+
+        Assert.Equal(BacnetReinitializedStates.BACNET_REINIT_WARMSTART, state);
+        Assert.Equal("AbCdEfGh", password);
+    }
+
+    [Fact] // F.4.7 - TimeSynchronization request decodes back to the same instant (hundredths resolution)
+    public void F_4_7_TimeSynchronization_round_trips()
+    {
+        var when = new DateTime(1992, 11, 17, 22, 45, 30).AddMilliseconds(700);
+
+        var buffer = new EncodeBuffer();
+        Services.EncodeTimeSync(buffer, when);
+
+        Services.DecodeTimeSync(buffer.buffer, 0, buffer.GetLength(), out var decoded);
+
+        Assert.Equal(when, decoded);
+    }
+
+    [Fact] // F.4.8 - Who-Has by object id decodes back to the object id
+    public void F_4_8_WhoHas_by_id_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeWhoHasBroadcast(buffer, -1, -1, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 3), null);
+
+        Services.DecodeWhoHasBroadcast(buffer.buffer, 0, buffer.GetLength(),
+            out var lowLimit, out var highLimit, out var objId, out var objName);
+
+        Assert.Equal(-1, lowLimit);
+        Assert.Equal(-1, highLimit);
+        Assert.Equal(new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_INPUT, 3), objId);
+        Assert.True(string.IsNullOrEmpty(objName));
+    }
+
+    [Fact] // F.4.8 - Who-Has by object name decodes back to the object name
+    public void F_4_8_WhoHas_by_name_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeWhoHasBroadcast(buffer, -1, -1, null, "OATemp");
+
+        Services.DecodeWhoHasBroadcast(buffer.buffer, 0, buffer.GetLength(),
+            out var lowLimit, out var highLimit, out var objId, out var objName);
+
+        Assert.Equal(-1, lowLimit);
+        Assert.Equal(-1, highLimit);
+        Assert.Null(objId);
+        Assert.Equal("OATemp", objName);
+    }
+
+    [Fact] // F.4.9 - Who-Is with an id range decodes back to the range
+    public void F_4_9_WhoIs_by_id_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeWhoIsBroadcast(buffer, 3, 3);
+
+        Services.DecodeWhoIsBroadcast(buffer.buffer, 0, buffer.GetLength(), out var lowLimit, out var highLimit);
+
+        Assert.Equal(3, lowLimit);
+        Assert.Equal(3, highLimit);
+    }
+
+    [Fact] // F.4.9 - Who-Is with no parameters decodes back to the unbounded range
+    public void F_4_9_WhoIs_all_round_trips()
+    {
+        var buffer = new EncodeBuffer();
+        Services.EncodeWhoIsBroadcast(buffer, -1, -1);
+
+        Services.DecodeWhoIsBroadcast(buffer.buffer, 0, buffer.GetLength(), out var lowLimit, out var highLimit);
+
+        Assert.Equal(-1, lowLimit);
+        Assert.Equal(-1, highLimit);
     }
 }

--- a/Tests/Serialize/Asn1PrimitiveTests.cs
+++ b/Tests/Serialize/Asn1PrimitiveTests.cs
@@ -141,4 +141,24 @@ public class Asn1PrimitiveTests
 
         Assert.Equal(new byte[] { 0x00, 0x00, 0x00, 0x0A }, buffer.ToArray());
     }
+
+    // --- Date (year-1900, month, day, day-of-week) ---
+
+    [Theory] // BACnet numbers the days Monday = 1 .. Sunday = 7 (Clause 20.2.12), unlike .NET's DayOfWeek.
+    [InlineData(2018, 2, 26, 1)] // Monday
+    [InlineData(2018, 2, 27, 2)] // Tuesday
+    [InlineData(2018, 2, 28, 3)] // Wednesday
+    [InlineData(2018, 3, 1, 4)]  // Thursday
+    [InlineData(2018, 3, 2, 5)]  // Friday
+    [InlineData(2018, 3, 3, 6)]  // Saturday
+    [InlineData(2018, 3, 4, 7)]  // Sunday
+    public void Date_encodes_the_day_of_week_per_the_standard(int year, int month, int day, byte expectedDayOfWeek)
+    {
+        var buffer = new EncodeBuffer();
+        ASN1.encode_bacnet_date(buffer, new DateTime(year, month, day));
+        var bytes = buffer.ToArray();
+
+        Assert.Equal(4, bytes.Length);
+        Assert.Equal(expectedDayOfWeek, bytes[3]);
+    }
 }


### PR DESCRIPTION
Ports the still-relevant test coverage from the long-standing community PR #25
(@DarkStarDS9), adapted to xUnit and the flat v4 API, so we can carry that work
forward and decline #25.

The existing `AshraeAnnexF{,2,3}Tests` assert every Annex F golden vector on the
**encode** side. #25 also covered the **decode** side, which v4 was missing — so a
number of service decoders had no test at all. This adds those decode round-trips
plus a few smaller gaps #25 identified.

## Bug fixed

- **`Services.DecodeCreateObject`** only handled the objectSpecifier `[1]`
  object-identifier choice. A request produced by the library's own
  `EncodeCreateObject(BacnetObjectTypes, …)` overload — the `[0]` object-type form
  where the device assigns the instance (ASHRAE 135 F.3.3) — could not be decoded.
  Now both choices decode; the object-type form is reported as the type with an
  unspecified (`BACNET_MAX_INSTANCE`) instance. This is the same fix #25 made,
  adapted to v4's `out BacnetObjectId` signature (no public-API break).

## Tests added

- **Annex F.1 / F.4** — decode round-trips for UnconfirmedCOVNotification,
  ConfirmedEventNotification, GetAlarmSummary-ack, GetEventInformation-ack,
  SubscribeCOV, SubscribeCOVProperty, DeviceCommunicationControl,
  ReinitializeDevice, TimeSynchronization, Who-Has (by id / by name),
  Who-Is (range / all).
- **Annex F.2** — AtomicReadFile stream-ack and AtomicWriteFile (stream + record)
  request round-trips.
- **Annex F.3** — CreateObject (by type and by object-id), DeleteObject,
  ReadPropertyMultiple request (single + multi-object) and ack, a single trend-log
  record round-trip, and a negative test that a corrupted ReadProperty-ack tag is
  rejected.
- **`BacnetBitString`** — `SetBit`/`GetBit`, `bits_used` growth, `ConvertToInt`,
  and the `ConvertFromInt` ↔ `ConvertToInt` round-trip.
- **ASN.1** — `encode_bacnet_date` day-of-week mapping (Mon = 1 … Sun = 7).

## Not ported from #25

- The event-notification tests and the `BacnetObjectPropertyReference` test target
  #25's refactored event model (`StateTransition<T>`, `EventValues.*`), which v4
  deliberately did not adopt in favour of the flat `BacnetEventNotificationData`.
- #25's `BacnetBitString` value-equality / `HashSet` tests require adding
  `Equals`/`GetHashCode` to the struct — a design change, not a test.

## Verification

- Full suite: **346 tests pass** on net8.0 (the test project's only target).
- The library builds clean across `net48;netstandard2.0;net8.0;net10.0`.

Credit: @DarkStarDS9 (#25).
