### PR TITLE
docs: correct and complete the 4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   actually evaluated), `BacnetDate.toDateTime()` → `ToDateTime()`. Decoded `Date_List`,
   `Weekly_Schedule` and `Exception_Schedule` values now carry dedicated application tags and typed
   objects instead of the opaque `CONTEXT_SPECIFIC_DECODED` shapes.
+- **`BacnetReliability` renumbered** to match the standard's enumeration (see MIGRATION.md):
+  `RELIABILITY_MEMBER_FAULT` moves 11 → 13 and `RELIABILITY_TRIPPED` 13 → 15 (11 is reserved by
+  ASHRAE 135 and is now `RELIABILITY_RESERVED_11`), and the values the enum was missing, 14 and
+  16-25, are added. 3.x sent and interpreted the two wrong numbers on the wire; code that persisted
+  or compared the numeric values keeps compiling and silently changes meaning.
+- **`BacnetLogRecord.statusFlags`** is now a `BacnetStatusFlags` instead of a `BacnetBitString`, and
+  the `BacnetLogRecord(type, value, stamp, status)` constructor takes the same enum in place of a raw
+  `uint`. Trend-log records encode and decode it as the fixed 4-bit BACnetStatusFlags string.
+- **`BacnetRejectReason.RECOGNIZED_SERVICE` → `UNRECOGNIZED_SERVICE`**: reject reason 9 means the
+  service is *not* recognized (ASHRAE 135 §18.8) - the member had always been spelled without the
+  negation. The value (9) is unchanged, so only a rename is needed at call sites.
 - **`BacnetDeviceObjectPropertyReference`**: the misspelled public field `deviceIndentifier` is now
   `deviceIdentifier` (the constructor parameter included).
 - **`Services.EncodeCreateProperty` → `EncodeCreateObject`**: the encoder was misnamed - it encodes
@@ -29,16 +40,30 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   request methods are unaffected.
 
 ### Added
-- Multi-targeting: `net48;netstandard2.0;net8.0;net10.0`.
+- Multi-targeting: `net48;netstandard2.0;net8.0;net10.0` for the core, `net48;net8.0;net10.0` for
+  `BACnet.Ethernet` and `BACnet.Serial` (their native dependencies have no netstandard2.0 target).
 - New packages: `BACnet.Ethernet`, `BACnet.Serial`, `BACnet.Logging.CommonLogging`.
 - Central Package Management, MinVer tag-driven versioning, Source Link + symbol (`.snupkg`) packages.
+- Every package ships its XML documentation file, so consumers get IntelliSense tooltips for the
+  doc-commented API, and `dotnet pack` runs the SDK's package validation across all four targets.
 - `BacnetIpUdpProtocolTransport` and `BacnetIpV6UdpProtocolTransport` accept a `maxApdu` constructor
   parameter to lower the advertised and sent APDU size (e.g. `MAX_APDU1024` keeps every frame,
   including segmented responses, under a 1500-byte MTU instead of relying on IP fragmentation).
+- `BacnetIpUdpProtocolTransport.ReceiveBufferSize` sets the UDP receive buffer (SO_RCVBUF) and may be
+  changed at any time, including after `Start()`. It now defaults to 1 MB rather than the OS default,
+  so a burst of incoming messages is far less likely to be dropped by the socket (on Linux the
+  effective size is still capped by `net.core.rmem_max`).
 - CI: multi-OS build matrix; tag-triggered publish to both nuget.org (Trusted Publishing) and GitHub Packages.
 - Runnable sample projects moved in-repo under `Examples/` and built in CI.
-- ASHRAE 135 Annex F golden-vector encode/decode tests - complete: all 62 Annex F example
-  encodings are asserted byte-for-byte.
+- ASHRAE 135 Annex F golden-vector tests: 83 encode/decode assertions covering 27 of Annex F's 37
+  example encodings, asserted byte-for-byte. Not covered yet: AcknowledgeAlarm (F.1.1),
+  GetEnrollmentSummary (F.1.7), the COVNotificationMultiple family (F.1.12-14), WriteGroup
+  (F.3.11-13) and TextMessage (F.4.5-6).
+- `BacnetPropertyReference`'s `arrayIndex` constructor parameter now defaults to
+  `ASN1.BACNET_ARRAY_ALL`, which omits the optional index from the request so the whole property is
+  read or written; there is also an overload taking a `BacnetPropertyIds` instead of a raw `uint`.
+  Passing 0 selects the array *length*, which is what made hand-built references to scalar
+  properties fail.
 - `Services.EncodeCreateObject` overload taking a `BacnetObjectTypes` (CreateObject by object type,
   the device assigns the instance number) and `Services.EncodeDeleteObject`.
 - PrivateTransfer send/receive support in `BacnetClient` (#154): `PrivateTransferRequest`,
@@ -63,8 +88,23 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
 ### Changed
 - The core package is now pure-managed with no native dependencies (closes the pcap → log4net chain, #112).
 - SharpPcap bumped 4.x → 6.x in `BACnet.Ethernet` (drops the vulnerable transitive log4net).
+- The BACnet/IP transport no longer hex-formats every received packet to build a log message that was
+  usually discarded, removing an allocation per datagram on the receive path (#152).
 
 ### Fixed
+- A busy BACnet/IP client no longer overflows the stack: when `EndReceive` completed synchronously
+  (typical under sustained load), the receive handler re-armed the socket with `BeginReceive` from
+  inside its own `finally` block and recursed into itself. The re-arm is queued to the thread pool so
+  the stack unwinds between receives (#150).
+- `EndReadPropertyRequest` no longer deadlocks when the device answers with an Error-APDU: it read
+  `res.Error` before waiting for completion and could dispose the async result while the receive
+  thread was still signalling it. It now waits for completion, then reads the error, then disposes
+  (#153).
+- `EndSubscribeCOVRequest` had the same read-before-wait, so device rejections (e.g. unknown-object)
+  were swallowed and came back as a null exception instead of a failure (#147, #148).
+- WhoIs/I-Am broadcast works on Linux: the exclusive-port socket is bound explicitly with
+  `ExclusiveAddressUse = false` + `SO_REUSEADDR` rather than through the `UdpClient(IPEndPoint)`
+  constructor, which binds before those options can be applied (#157).
 - `Services.DecodeCreateObject` now decodes the CreateObject "by object type" request form
   (objectSpecifier choice `[0]`, where the device assigns the instance number) as well as the
   "by object identifier" form (`[1]`). Only `[1]` was decoded before, so a request produced by the
@@ -132,8 +172,25 @@ See [MIGRATION.md](MIGRATION.md) for upgrade guidance.
   library returned (the tolerant decoder hid it from same-stack round-trips) (#199). Context wrapping
   is now explicit at the call sites whose ASN.1 requires it (private-transfer error-type `[0]`,
   trend-log failure log-datum `[8]`).
+- `BacnetBitString.ConvertFromInt` counted significant bits as `ceil(log2(value))`, which under-counted
+  every exact power of two (4 gave 2 bits instead of 3) and gave 0 bits for the value 1, so those bit
+  strings went on the wire a bit short. It is `floor(log2(value)) + 1` now, and callers that know the
+  standard-defined width can pass it explicitly (#8).
+- `ReadRangeResponse` encodes BACnetResultFlags as the fixed 3-bit BIT STRING the standard defines
+  (ASHRAE 135 §20.2.10 requires all defined bits present): the width used to be derived from the enum
+  value, so all-false flags collapsed to an empty, non-conformant bit string (#171, PR #15).
+- `encode_bacnet_signed` used a strict `>` lower bound, so `int.MinValue` took the 8-byte signed64 path
+  while `decode_signed` only handles 1-4 bytes - the value silently decoded back to 0. The whole int32
+  range round-trips now.
+- `Time_Of_Device_Restart` decodes as a BACnetTimeStamp (ASHRAE 135 §12.11.45) through the same path as
+  `Event_Time_Stamps`, instead of as a bare application value (#142, svn@525).
+- BVLC broadcast-distribution and foreign-device table entries decode addresses as unsigned: an IP
+  whose last octet was ≥ 128 (e.g. 192.168.0.137) produced a negative `int`, which `new IPAddress(long)`
+  rejects, so reading such a BDT/FDT threw (#123).
+- `BACnet.Serial` reports a clear error, with the fix, when the `System.IO.Ports` native library is
+  missing from a publish rather than failing obscurely on open (#201, see MIGRATION.md).
 - Multi-object `WritePropertyMultiple` decoding (#158), DATE/TIME/DATETIME culture-invariant
-  serialization (#159), float/double property serialization (#143), and several encoder fixes surfaced
-  by the Annex F vectors (wildcard time, private-transfer ack, log-record status flags).
+  serialization (#159), REAL/DOUBLE/UNSIGNED_INT property serialization (#143), and several encoder
+  fixes surfaced by the Annex F vectors (wildcard time, private-transfer ack).
 - `GetAddressDefaultInterface` now throws a helpful error instead of returning null when the local
   interface is ambiguous (#100).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -195,6 +195,56 @@ original octets via the new `BacnetGenericTime.PartialTime` while `Time` keeps t
 best-effort clamped value, and a wildcarded Date+Time property pair merges into the new
 `BacnetDateTime` struct instead of a clamped `DateTime`.
 
+## `BacnetReliability` values are renumbered
+
+The enum did not match ASHRAE 135. Two members had the wrong numbers and everything above 13 was
+missing, so 3.x both sent and interpreted the wrong values on the wire for them:
+
+| Member | 3.x | 4.0 |
+|--------|-----|-----|
+| `RELIABILITY_COMMUNICATION_FAILURE` | 12 | 12 (unchanged) |
+| `RELIABILITY_MEMBER_FAULT` | 11 | **13** |
+| `RELIABILITY_TRIPPED` | 13 | **15** |
+
+Value 11 is reserved for a future addendum by the standard and is now `RELIABILITY_RESERVED_11`. The
+members the enum lacked are added: `RELIABILITY_MONITORED_OBJECT_FAULT` (14),
+`RELIABILITY_LAMP_FAILURE` (16), `RELIABILITY_ACTIVATION_FAILURE` (17),
+`RELIABILITY_RENEW_DHCP_FAILURE` (18), `RELIABILITY_RENEW_FD_REGISTRATION_FAILURE` (19),
+`RELIABILITY_RESTART_AUTO_NEGOTIATION_FAILURE` (20), `RELIABILITY_RESTART_FAILURE` (21),
+`RELIABILITY_PROPRIETARY_COMMAND_FAILURE` (22), `RELIABILITY_FAULTS_LISTED` (23),
+`RELIABILITY_REFERENCED_OBJECT_FAULT` (24) and `RELIABILITY_MULTI_STATE_OUT_OF_RANGE` (25).
+
+Code that uses the enum members by name needs no change and starts putting the correct values on the
+wire. **Code that stored or transported the numbers does need attention**: a database column, config
+file or protocol bridge holding 11 or 13 from 3.x now means something different, and it keeps
+compiling. Migrate persisted 11 → 13 and 13 → 15, in that order.
+
+## `BacnetLogRecord.statusFlags` is a `BacnetStatusFlags`
+
+The trend-log record's status field was an untyped `BacnetBitString` built from a raw `uint`, which lost
+the meaning of the bits and encoded a variable number of them. It is now the `BacnetStatusFlags` enum,
+and records encode/decode it as the fixed 4-bit BACnetStatusFlags string the standard defines:
+
+```diff
+- var record = new BacnetLogRecord(type, value, stamp, (uint)BacnetStatusFlags.STATUS_FLAG_IN_ALARM);
++ var record = new BacnetLogRecord(type, value, stamp, BacnetStatusFlags.STATUS_FLAG_IN_ALARM);
+- if (record.statusFlags.GetBit(0)) { ... }
++ if (record.statusFlags.HasFlag(BacnetStatusFlags.STATUS_FLAG_IN_ALARM)) { ... }
+```
+
+## `BacnetRejectReason.RECOGNIZED_SERVICE` → `UNRECOGNIZED_SERVICE`
+
+Reject reason 9 is returned when the service in a confirmed request is unknown or unsupported
+(ASHRAE 135 §18.8), but the member had always been spelled without the negation - 3.x even carried
+the comment *"should be unrecognized but this is the way it was spelled"*. Only the name changed:
+
+```diff
+- SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.RECOGNIZED_SERVICE);
++ SendConfirmedServiceReject(address, invokeId, BacnetRejectReason.UNRECOGNIZED_SERVICE);
+```
+
+The numeric value stays 9, so nothing changes on the wire and persisted values need no migration.
+
 ## `Services.EncodeCreateProperty` → `EncodeCreateObject`
 
 This low-level encoder was misnamed: it encodes a **CreateObject-Request** (BACnet has no


### PR DESCRIPTION
Audit of the `## 4.0.0` changelog section against all 74 commits since `3.0.2`, ahead of tagging the
stable release. Docs only, no code changes.

This matters more than usual because the release workflow is about to source the GitHub Release body
from this section (auto-generated notes would be empty: the stable tag sits on the same commit
`v4.0.0-beta.4` was cut from).

## Three breaking changes were undocumented

Each gets a `### Breaking` entry and a MIGRATION.md section:

- **`BacnetReliability` renumbered** - `RELIABILITY_MEMBER_FAULT` 11 → 13, `RELIABILITY_TRIPPED`
  13 → 15, 11 becomes `RELIABILITY_RESERVED_11`, values 14 and 16-25 added. Verified against the
  `BACnetReliability ::= ENUMERATED` production in ASHRAE 135-2016, including its "value 11 is
  reserved for a future addendum" note. This is the dangerous one: code that persisted or compared
  the numeric values keeps compiling and silently changes meaning, so the migration guide gives the
  11 → 13 / 13 → 15 order to apply.
- **`BacnetLogRecord.statusFlags`** is now a `BacnetStatusFlags` instead of a `BacnetBitString`, and
  the constructor takes the enum in place of a raw `uint`.
- **`BacnetRejectReason.RECOGNIZED_SERVICE` → `UNRECOGNIZED_SERVICE`** - rename only, value stays 9.

## One claim was false

"complete: all 62 Annex F example encodings are asserted byte-for-byte" does not hold. Annex F
defines **37** numbered example encodings (F.1.1-14, F.2.1-2, F.3.1-13 less the deleted F.3.6,
F.4.1-9); the suite covers **27** of them across 83 `[Fact]`s. The entry now states that, and lists
what is not covered: AcknowledgeAlarm (F.1.1), GetEnrollmentSummary (F.1.7), the
COVNotificationMultiple family (F.1.12-14), WriteGroup (F.3.11-13) and TextMessage (F.4.5-6).

Also corrected: the multi-targeting line now notes that `BACnet.Ethernet` and `BACnet.Serial` target
`net48;net8.0;net10.0`, without netstandard2.0.

## Missing entries added

**Added / Changed:** configurable UDP receive buffer (SO_RCVBUF, new 1 MB default);
`BacnetPropertyReference` array-index default of `BACNET_ARRAY_ALL` plus the `BacnetPropertyIds`
overload; XML docs shipped in every package plus pack-time package validation; the per-datagram
`ConvertToHex` allocation removed from the receive path.

**Fixed** - ten changes that had no line at all: stack overflow in the UDP receive loop (#150), the
`EndReadPropertyRequest` deadlock and the swallowed `EndSubscribeCOVRequest` rejection (#153, #147,
#148), Linux broadcast binding (#157), `BacnetBitString` bit counting (#8), ReadRange result flags
(#171), `int.MinValue` encoding, `Time_Of_Device_Restart` (#142), unsigned BDT/FDT addresses (#123),
and the `System.IO.Ports` diagnostic (#201).

Each description comes from the commit body and diff rather than the subject line - the subjects are
misleading in a few cases (both APM bugs are the same read-before-wait, and the ReadProperty one
deadlocks by disposing the async result while the receive thread is still signalling it).

## Verified

- Release-notes extraction still parses the section: 15,909 chars, 188 lines, all four `###` groups.
- All remaining changelog claims spot-checked against `3.0.2` and `master`: the five renames
  (`toDateTime`, `deviceIndentifier`, `EncodeCreateProperty`, `BACnetCalendarEntry`,
  `BacnetweekNDay`) are gone from master, SharpPcap 4.2/4.5 → 6.3.1, `Log` is `ILogger` with
  `BacnetLogging.Factory`, MS/TP + PTP still in the core with `SerialTransport.Mstp`/`.Ptp`,
  `GetSegmentBuffer(maxSegments, requesterMaxAdpu)`, `IHave(… source, receiver)` with `receiver`
  appended last, `ASN1.BACNET_TIME_WILDCARD`, `bacapp_decode_timestamp`, the three typed async
  results, and async parity (23 `…Async` methods, one per confirmed request method).