### PR TITLE
fix: serialize SIGNED_INT property values with the invariant culture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project are documented here. The format is based on
   fell through to the default branch of `Property.SerializeValue` and used the current culture, so a
   host whose culture spells the negative sign U+2212 (sv-SE and friends, under ICU) wrote `−5` into
   the device storage XML - a value neither bacnet-stack, nor YABE, nor this library on an
-  ASCII-hyphen host can read back. The SIGNED_INT and UNSIGNED_INT parsers in
+  ASCII-hyphen host can read back. The SIGNED_INT, UNSIGNED_INT and ENUMERATED parsers in
   `Property.DeserializeValue` take the invariant culture too, so both directions state the same
   format instead of relying on `int.Parse` accepting the ASCII hyphen under any culture.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project follows tag-driven
 [MinVer](https://github.com/adamralph/minver) versioning.
 
-## Unreleased
+## 4.1.0
 
 ### Added
 - **Logging scopes**: every log entry about a request or an answer is written inside a
@@ -12,6 +12,15 @@ All notable changes to this project are documented here. The format is based on
   `RemoteAddress` property. Sinks can print it (`IncludeScopes`) or use it to route the traffic of
   each device to its own log when one `BacnetClient` serves several devices. Broadcasts have no
   remote device and get no scope. Sinks that ignore scopes see no change.
+
+### Fixed
+- SIGNED_INT property values serialize with the invariant culture, like the other numeric tags. They
+  fell through to the default branch of `Property.SerializeValue` and used the current culture, so a
+  host whose culture spells the negative sign U+2212 (sv-SE and friends, under ICU) wrote `−5` into
+  the device storage XML - a value neither bacnet-stack, nor YABE, nor this library on an
+  ASCII-hyphen host can read back. The SIGNED_INT and UNSIGNED_INT parsers in
+  `Property.DeserializeValue` take the invariant culture too, so both directions state the same
+  format instead of relying on `int.Parse` accepting the ASCII hyphen under any culture.
 
 ## 4.0.0
 

--- a/Storage/Property.cs
+++ b/Storage/Property.cs
@@ -36,9 +36,9 @@ public class Property
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_BOOLEAN:
                 return new BacnetValue(type, bool.Parse(value));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT:
-                return new BacnetValue(type, uint.Parse(value));
+                return new BacnetValue(type, uint.Parse(value, CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_SIGNED_INT:
-                return new BacnetValue(type, int.Parse(value));
+                return new BacnetValue(type, int.Parse(value, CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_REAL:
                 return new BacnetValue(type, float.Parse(value, CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_DOUBLE:
@@ -155,6 +155,11 @@ public class Property
                 return Convert.ToDouble(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_UNSIGNED_INT:
                 return Convert.ToUInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
+            case BacnetApplicationTags.BACNET_APPLICATION_TAG_SIGNED_INT:
+                // Without the invariant culture the negative sign follows the current culture -
+                // sv-SE and friends emit U+2212 rather than the ASCII hyphen every other
+                // BACnet tool expects.
+                return Convert.ToInt32(value.Value, CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_OCTET_STRING:
                 return Convert.ToBase64String((byte[])value.Value);
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_CONTEXT_SPECIFIC_DECODED:

--- a/Storage/Property.cs
+++ b/Storage/Property.cs
@@ -66,7 +66,7 @@ public class Property
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_BIT_STRING:
                 return new BacnetValue(type, BacnetBitString.Parse(value));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_ENUMERATED:
-                return new BacnetValue(type, uint.Parse(value));
+                return new BacnetValue(type, uint.Parse(value, CultureInfo.InvariantCulture));
             case BacnetApplicationTags.BACNET_APPLICATION_TAG_DATE:
                 // Format: yyyy/MM/dd (bacnet-stack compatible); date patterns are stored as base64
                 try

--- a/Tests/Storage/PropertyCultureTests.cs
+++ b/Tests/Storage/PropertyCultureTests.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using System.IO.BACnet.Storage;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// The device storage XML is a portable, tool-neutral file: bacnet-stack and YABE both
+/// read and write it. REAL, DOUBLE and UNSIGNED_INT were made culture-invariant in #143,
+/// but SIGNED_INT still round-trips through the current culture on both sides.
+/// Under ICU, sv-SE uses U+2212 (MINUS SIGN) rather than the ASCII hyphen.
+/// </summary>
+public class PropertyCultureTests
+{
+    private const string Culture = "sv-SE";
+
+    [Fact]
+    public void SignedInt_serializes_invariant()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(Culture);
+            var bv = new BacnetValue(BacnetApplicationTags.BACNET_APPLICATION_TAG_SIGNED_INT, -5);
+
+            var s = Property.SerializeValue(bv, BacnetApplicationTags.BACNET_APPLICATION_TAG_SIGNED_INT);
+
+            Assert.Equal("-5", s);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+
+    [Fact]
+    public void SignedInt_deserializes_ascii_hyphen()
+    {
+        var previous = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo(Culture);
+
+            var bv = Property.DeserializeValue("-5", BacnetApplicationTags.BACNET_APPLICATION_TAG_SIGNED_INT);
+
+            Assert.Equal(-5, bv.Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previous;
+        }
+    }
+}


### PR DESCRIPTION
## What

`Property.SerializeValue` has no case for `BACNET_APPLICATION_TAG_SIGNED_INT`, so signed integers
fall through to the default branch (`value.Value.ToString()`) and are formatted with the **current
culture**.

Under ICU, `sv-SE` and several other cultures spell the negative sign `U+2212 MINUS SIGN` rather than
the ASCII hyphen. A host in such a culture therefore writes `−5` into the device storage XML — a file
that is meant to be tool-neutral, since bacnet-stack and YABE read it as well. Nothing else can parse
that value back, including this library itself running on an ASCII-hyphen host.

`REAL`, `DOUBLE` and `UNSIGNED_INT` were made culture-invariant in #143; `SIGNED_INT` was missed.

## Reproduction

`Tests/Storage/PropertyCultureTests.cs` in this PR. Before the fix, serializing `-5` under `sv-SE`:

```
Assert.Equal() Failure: Strings differ
Expected: "-5"   (U+002D HYPHEN-MINUS)
Actual:   "−5"   (U+2212 MINUS SIGN)
```

## Changes

- `SerializeValue`: an explicit `SIGNED_INT` case, shaped like the `UNSIGNED_INT` case directly above
  it (`Convert.ToInt32(..., CultureInfo.InvariantCulture).ToString(CultureInfo.InvariantCulture)`).
- `DeserializeValue`: the invariant culture is passed to the `int` / `uint` parsers. To be clear about
  scope, this direction was **not** broken — `int.Parse` accepts the ASCII hyphen even under `sv-SE`,
  so the second test passes on `v4` as it is. The change removes the reliance on that leniency and
  makes both directions state the same contract.
- Tests pinning both directions under `sv-SE`.
- A changelog entry under `4.0.0` → `Fixed`.

No public API change.

## Verification

- `dotnet build BACnet.slnx -c Release` — clean, 0 warnings, 0 errors
- `dotnet test BACnet.slnx -c Release` — 353/353 passing (351 before, plus the 2 added here)
- Branched from `v4` per CONTRIBUTING.md
