### PR TITLE
feat(logging): scope every request and answer log entry to the remote device

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -171,6 +171,18 @@ public class BacnetClient : IDisposable
         return new EncodeBuffer(new byte[Transport.MaxBufferLength], startOffset);
     }
 
+    /// <summary>
+    /// Attaches the address of the remote device to every log entry written until the returned
+    /// scope is disposed. A client that talks to several devices logs all requests and answers
+    /// through the same <see cref="Log"/>; the scope is what lets a log sink tell them apart.
+    /// The state is a standard message-template scope with a single <c>RemoteAddress</c> property.
+    /// Broadcasts have no remote device and get no scope.
+    /// </summary>
+    private IDisposable BeginRemoteScope(BacnetAddress address)
+    {
+        return address == null ? null : Log.BeginScope("{RemoteAddress}", address);
+    }
+
     public void Start()
     {
         Transport.Start();
@@ -1030,6 +1042,7 @@ public class BacnetClient : IDisposable
 
     private void OnRecieve(IBacnetTransport sender, byte[] buffer, int offset, int msgLength, BacnetAddress remoteAddress)
     {
+        using var remoteScope = BeginRemoteScope(remoteAddress);
         try
         {
             if (Transport == null)
@@ -1145,6 +1158,7 @@ public class BacnetClient : IDisposable
 
     public void WhoIs(int lowLimit = -1, int highLimit = -1, BacnetAddress receiver = null, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(receiver);
         BacnetAddress npduDestination;
         if (receiver == null)
         {
@@ -1172,6 +1186,7 @@ public class BacnetClient : IDisposable
 
     public void Iam(uint deviceId, BacnetSegmentations segmentation = BacnetSegmentations.SEGMENTATION_BOTH, BacnetAddress receiver = null, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(receiver);
         BacnetAddress npduDestination;
         if (receiver == null)
         {
@@ -1209,6 +1224,7 @@ public class BacnetClient : IDisposable
 
     private void WhoHasCore(BacnetObjectId? objId, string objName, int lowLimit, int highLimit, BacnetAddress receiver, BacnetAddress source)
     {
+        using var remoteScope = BeginRemoteScope(receiver);
         BacnetAddress npduDestination;
         if (receiver == null)
         {
@@ -1238,6 +1254,7 @@ public class BacnetClient : IDisposable
     // meaning; harmonize the order in 5.0 alongside the namespace rename
     public void IHave(BacnetObjectId deviceId, BacnetObjectId objId, string objName, BacnetAddress source = null, BacnetAddress receiver = null)
     {
+        using var remoteScope = BeginRemoteScope(receiver);
         BacnetAddress npduDestination;
         if (receiver == null)
         {
@@ -1264,6 +1281,7 @@ public class BacnetClient : IDisposable
 
     public void SendUnconfirmedEventNotification(BacnetAddress adr, BacnetEventNotificationData eventData, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1277,6 +1295,7 @@ public class BacnetClient : IDisposable
 
     public void SendUnconfirmedPrivateTransfer(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters = null, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending UnconfirmedPrivateTransfer vendor {vendorId} service {serviceNumber}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1288,6 +1307,7 @@ public class BacnetClient : IDisposable
 
     public void SendConfirmedServiceReject(BacnetAddress adr, byte invokeId, BacnetRejectReason reason)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending Service reject: {reason}");
 
         var b = GetEncodeBuffer(Transport.HeaderLength);
@@ -1299,6 +1319,7 @@ public class BacnetClient : IDisposable
 
     public void SendAbort(BacnetAddress adr, byte invokeId, BacnetAbortReason reason)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         // DAL
         Log.LogDebug($"Sending Service reject: {reason}");
 
@@ -1311,6 +1332,7 @@ public class BacnetClient : IDisposable
 
     public void SynchronizeTime(BacnetAddress adr, DateTime dateTime, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending Time Synchronize: {dateTime} {dateTime.Kind.ToString().ToUpper()}");
 
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
@@ -1390,6 +1412,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWriteFileRequest(BacnetAddress adr, BacnetObjectId objectId, int position, int count, byte[] fileBuffer, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending AtomicWriteFileRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1429,6 +1452,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadFileRequest(BacnetAddress adr, BacnetObjectId objectId, int position, uint count, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending AtomicReadFileRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1510,6 +1534,7 @@ public class BacnetClient : IDisposable
 
     private IAsyncResult BeginReadRangeRequestCore(BacnetAddress adr, BacnetObjectId objectId, BacnetReadRangeRequestTypes bacnetReadRangeRequestTypes, DateTime readFrom, uint idxBegin, uint quantity, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending ReadRangeRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1616,6 +1641,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginSubscribeCOVRequest(BacnetAddress adr, BacnetObjectId objectId, uint subscribeId, bool cancel, bool issueConfirmedNotifications, uint lifetime, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending SubscribeCOVRequest {objectId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1663,6 +1689,7 @@ public class BacnetClient : IDisposable
     // DAL
     public IAsyncResult BeginSendConfirmedEventNotificationRequest(BacnetAddress adr, BacnetEventNotificationData eventData, bool waitForTransmit, byte invokeId = 0, BacnetAddress source = null)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending Confirmed Event Notification {eventData.eventType} {eventData.eventObjectIdentifier}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1712,6 +1739,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginSubscribePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference monitoredProperty, uint subscribeId, bool cancel, bool issueConfirmedNotifications, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending SubscribePropertyRequest {objectId}.{monitoredProperty}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1797,6 +1825,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadPropertyRequest(BacnetAddress address, BacnetObjectId objectId, BacnetPropertyIds propertyId, bool waitForTransmit, byte invokeId = 0, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
+        using var remoteScope = BeginRemoteScope(address);
         Log.LogDebug($"Sending ReadPropertyRequest {objectId} {propertyId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -1880,6 +1909,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWritePropertyRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, IEnumerable<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0, byte? priority = null, uint arrayIndex = ASN1.BACNET_ARRAY_ALL)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         if (priority.HasValue && (priority < 1 || priority > 16))
             throw new ArgumentOutOfRangeException(nameof(priority), "WritePropertyRequest priority must be between 1 and 16");
 
@@ -1901,6 +1931,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWritePropertyMultipleRequest(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending WritePropertyMultipleRequest {objectId}");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -1951,6 +1982,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginWritePropertyMultipleRequest(BacnetAddress adr, ICollection<BacnetReadAccessResult> valueList, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         var objectIds = string.Join(", ", valueList.Select(v => v.objectIdentifier));
         Log.LogDebug($"Sending WritePropertyMultipleRequest {objectIds}");
 
@@ -2019,6 +2051,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadPropertyMultipleRequest(BacnetAddress adr, BacnetObjectId objectId, IList<BacnetPropertyReference> propertyIdAndArrayIndex, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         var propertyIds = string.Join(", ", propertyIdAndArrayIndex.Select(v => (BacnetPropertyIds)v.propertyIdentifier));
         Log.LogDebug($"Sending ReadPropertyMultipleRequest {objectId} {propertyIds}");
         if (invokeId == 0)
@@ -2060,6 +2093,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReadPropertyMultipleRequest(BacnetAddress adr, IList<BacnetReadAccessSpecification> properties, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         var objectIds = string.Join(", ", properties.Select(v => v.objectIdentifier));
         Log.LogDebug($"Sending ReadPropertyMultipleRequest {objectIds}");
         if (invokeId == 0)
@@ -2128,6 +2162,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginCreateObjectRequest(BacnetAddress adr, BacnetObjectId objectId, ICollection<BacnetPropertyValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending CreateObjectRequest");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2177,6 +2212,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginDeleteObjectRequest(BacnetAddress adr, BacnetObjectId objectId, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending DeleteObjectRequest");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2250,6 +2286,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginRemoveListElementRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending RemoveListElementRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2268,6 +2305,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginAddListElementRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyReference reference, IList<BacnetValue> valueList, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending AddListElementRequest {objectId} {(BacnetPropertyIds)reference.propertyIdentifier}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2322,6 +2360,7 @@ public class BacnetClient : IDisposable
     // Fc
     public IAsyncResult BeginRawEncodedDecodedPropertyConfirmedRequest(BacnetAddress adr, BacnetObjectId objectId, BacnetPropertyIds propertyId, BacnetConfirmedServices serviceId, byte[] inOutBuffer, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending RawEncodedRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2404,6 +2443,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginDeviceCommunicationControlRequest(BacnetAddress adr, uint timeDuration, uint enableDisable, string password, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending DeviceCommunicationControlRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2453,6 +2493,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginPrivateTransferRequest(BacnetAddress adr, uint vendorId, uint serviceNumber, byte[] serviceParameters, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending PrivateTransferRequest vendor {vendorId} service {serviceNumber}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2521,6 +2562,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginGetAlarmSummaryOrEventRequest(BacnetAddress adr, bool getEvent, IList<BacnetGetEventInformationData> alarms, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending Alarm summary request");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2603,6 +2645,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginAlarmAcknowledgement(BacnetAddress adr, BacnetObjectId objId, BacnetEventStates eventState, string ackText, BacnetGenericTime evTimeStamp, BacnetGenericTime ackTimeStamp, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending AlarmAcknowledgement");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2647,6 +2690,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginReinitializeRequest(BacnetAddress adr, BacnetReinitializedStates state, string password, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending ReinitializeRequest");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -2675,6 +2719,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginConfirmedNotify(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, IList<BacnetPropertyValue> values, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending Notify (confirmed)");
         if (invokeId == 0) invokeId = (byte)Interlocked.Increment(ref _invokeId);
 
@@ -2700,6 +2745,7 @@ public class BacnetClient : IDisposable
 
     public bool Notify(BacnetAddress adr, uint subscriberProcessIdentifier, uint initiatingDeviceIdentifier, BacnetObjectId monitoredObjectIdentifier, uint timeRemaining, bool issueConfirmedNotifications, IList<BacnetPropertyValue> values)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         if (!issueConfirmedNotifications)
         {
             Log.LogDebug("Sending Notify (unconfirmed)");
@@ -2752,6 +2798,7 @@ public class BacnetClient : IDisposable
 
     public IAsyncResult BeginLifeSafetyOperationRequest(BacnetAddress address, BacnetObjectId objectId, uint processId, string requestingSrc, BacnetLifeSafetyOperations operation, bool waitForTransmit, byte invokeId = 0)
     {
+        using var remoteScope = BeginRemoteScope(address);
         Log.LogDebug($"Sending {ToTitleCase(operation)} {objectId}");
         if (invokeId == 0)
             invokeId = (byte)Interlocked.Increment(ref _invokeId);
@@ -3358,6 +3405,7 @@ public class BacnetClient : IDisposable
 
     private void SendComplexAck(BacnetAddress adr, byte invokeId, Segmentation segmentation, BacnetConfirmedServices service, Action<EncodeBuffer> apduContentEncode)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending {ToTitleCase(service)}");
 
         //encode
@@ -3473,6 +3521,7 @@ public class BacnetClient : IDisposable
 
     public void ErrorResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending ErrorResponse for {service}: {errorCode}");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
@@ -3483,6 +3532,7 @@ public class BacnetClient : IDisposable
 
     public void PrivateTransferErrorResponse(BacnetAddress adr, byte invokeId, BacnetErrorClasses errorClass, BacnetErrorCodes errorCode, uint vendorId, uint serviceNumber, byte[] errorParameters = null)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending PrivateTransferErrorResponse: {errorCode}");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
@@ -3493,6 +3543,7 @@ public class BacnetClient : IDisposable
 
     public void SimpleAckResponse(BacnetAddress adr, BacnetConfirmedServices service, byte invokeId)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug($"Sending SimpleAckResponse for {service}");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);
@@ -3502,6 +3553,7 @@ public class BacnetClient : IDisposable
 
     public void SegmentAckResponse(BacnetAddress adr, bool negative, bool server, byte originalInvokeId, byte sequenceNumber, byte actualWindowSize)
     {
+        using var remoteScope = BeginRemoteScope(adr);
         Log.LogDebug("Sending SegmentAckResponse");
         var buffer = GetEncodeBuffer(Transport.HeaderLength);
         NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, adr.RoutedSource, adr.RoutedDestination);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project follows tag-driven
 [MinVer](https://github.com/adamralph/minver) versioning.
 
+## Unreleased
+
+### Added
+- **Logging scopes**: every log entry about a request or an answer is written inside a
+  `Microsoft.Extensions.Logging` scope carrying the address of the remote device as the
+  `RemoteAddress` property. Sinks can print it (`IncludeScopes`) or use it to route the traffic of
+  each device to its own log when one `BacnetClient` serves several devices. Broadcasts have no
+  remote device and get no scope. Sinks that ignore scopes see no change.
+
 ## 4.0.0
 
 The 4.0 release modernises the build, packaging and dependencies of the library.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ BacnetLogging.Factory = LoggerFactory.Create(b => b.AddConsole());
 Console, Serilog, NLog, and log4net all work via their MEL providers. If you already use
 `Common.Logging`, add the `BACnet.Logging.CommonLogging` package and call `b.AddCommonLogging()`.
 
+Every entry about a request or an answer is written inside a logging scope carrying the address of
+the remote device as the `RemoteAddress` property (broadcasts have none). Structured sinks get it as
+a property, text sinks print it with `IncludeScopes`, and a client that talks to several devices can
+use it to route each device's traffic to its own log:
+
+```csharp
+BacnetLogging.Factory = LoggerFactory.Create(b => b.AddSimpleConsole(o => o.IncludeScopes = true));
+// => 10.0.0.2:47808 Sending ReadPropertyRequest OBJECT_ANALOG_VALUE:1 PROP_PRESENT_VALUE
+```
+
 ## Upgrading from 3.x to 4.0
 
 4.0 has a few breaking changes — see [`MIGRATION.md`](https://github.com/ela-compil/BACnet/blob/master/MIGRATION.md) for details:

--- a/README.md
+++ b/README.md
@@ -125,16 +125,6 @@ BacnetLogging.Factory = LoggerFactory.Create(b => b.AddConsole());
 Console, Serilog, NLog, and log4net all work via their MEL providers. If you already use
 `Common.Logging`, add the `BACnet.Logging.CommonLogging` package and call `b.AddCommonLogging()`.
 
-Every entry about a request or an answer is written inside a logging scope carrying the address of
-the remote device as the `RemoteAddress` property (broadcasts have none). Structured sinks get it as
-a property, text sinks print it with `IncludeScopes`, and a client that talks to several devices can
-use it to route each device's traffic to its own log:
-
-```csharp
-BacnetLogging.Factory = LoggerFactory.Create(b => b.AddSimpleConsole(o => o.IncludeScopes = true));
-// => 10.0.0.2:47808 Sending ReadPropertyRequest OBJECT_ANALOG_VALUE:1 PROP_PRESENT_VALUE
-```
-
 ## Upgrading from 3.x to 4.0
 
 4.0 has a few breaking changes — see [`MIGRATION.md`](https://github.com/ela-compil/BACnet/blob/master/MIGRATION.md) for details:

--- a/Tests/BacnetClientLogScopeTests.cs
+++ b/Tests/BacnetClientLogScopeTests.cs
@@ -1,0 +1,93 @@
+using System.IO.BACnet.Tests.Support;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Every log entry about a request or an answer carries the address of the remote device as a
+/// logging scope, so that a sink serving a client that talks to several devices can tell them
+/// apart. Broadcasts have no remote device and no scope.
+/// </summary>
+public class BacnetClientLogScopeTests
+{
+    private static readonly BacnetAddress Device = new(BacnetAddressTypes.IP, "10.0.0.2:47808");
+
+    [Fact]
+    public void Requests_are_logged_within_the_scope_of_the_remote_device()
+    {
+        var logger = new RecordingLogger();
+        var client = new BacnetClient(new RecordingTransport()) { Log = logger };
+        client.Start();
+
+        client.BeginReadPropertyRequest(Device, new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1),
+            BacnetPropertyIds.PROP_PRESENT_VALUE, waitForTransmit: false);
+
+        var entry = logger.Entry("Sending ReadPropertyRequest");
+        var scope = Assert.Single(entry.Scopes);
+        Assert.Equal(Device, RecordingLogger.RemoteAddress(scope));
+        Assert.Equal(Device.ToString(), scope.ToString());
+    }
+
+    [Fact]
+    public void Unconfirmed_requests_are_logged_within_the_scope_of_the_receiver()
+    {
+        var logger = new RecordingLogger();
+        var client = new BacnetClient(new RecordingTransport()) { Log = logger };
+        client.Start();
+
+        client.Iam(1234, receiver: Device);
+
+        var scope = Assert.Single(logger.Entry("Sending Iam").Scopes);
+        Assert.Equal(Device, RecordingLogger.RemoteAddress(scope));
+    }
+
+    [Fact]
+    public void Broadcasts_are_logged_without_a_remote_device_scope()
+    {
+        var logger = new RecordingLogger();
+        var client = new BacnetClient(new RecordingTransport()) { Log = logger };
+        client.Start();
+
+        client.WhoIs();
+
+        Assert.Empty(logger.Entry("Broadcasting WhoIs").Scopes);
+    }
+
+    [Fact]
+    public void Received_frames_and_their_responses_are_logged_within_the_scope_of_the_sender()
+    {
+        var (transportA, transportB) = LoopbackTransport.CreatePair();
+        var clientLogger = new RecordingLogger();
+        var serverLogger = new RecordingLogger();
+        using var client = new BacnetClient(transportA, timeout: 500) { Log = clientLogger };
+        using var server = new BacnetClient(transportB, timeout: 500) { Log = serverLogger };
+        client.Start();
+        server.Start();
+
+        BacnetAddress requester = null;
+        server.OnWritePropertyRequest += (sender, adr, invokeId, objectId, value, maxSegments) =>
+        {
+            requester = adr;
+            sender.SimpleAckResponse(adr, BacnetConfirmedServices.SERVICE_CONFIRMED_WRITE_PROPERTY, invokeId);
+        };
+
+        client.WritePropertyRequest(client.Transport.GetBroadcastAddress(),
+            new BacnetObjectId(BacnetObjectTypes.OBJECT_ANALOG_VALUE, 1), BacnetPropertyIds.PROP_PRESENT_VALUE,
+            new[] { new BacnetValue(21.5f) });
+
+        Assert.NotNull(requester);
+
+        // the server logs the request and the answer it sends within the scope of the requester
+        var request = serverLogger.Entry("ConfirmedServiceRequest SERVICE_CONFIRMED_WRITE_PROPERTY");
+        Assert.Equal(requester, RecordingLogger.RemoteAddress(Assert.Single(request.Scopes)));
+
+        var response = serverLogger.Entry("Sending SimpleAckResponse");
+        Assert.All(response.Scopes, scope => Assert.Equal(requester, RecordingLogger.RemoteAddress(scope)));
+
+        // the client logs the answer within the scope of the device that sent it - the loopback
+        // delivers on the requesting thread, so the scope of the request itself is still open too
+        var ack = clientLogger.Entry("Received SimpleAck");
+        Assert.NotEmpty(ack.Scopes);
+        Assert.All(ack.Scopes, scope => Assert.NotNull(RecordingLogger.RemoteAddress(scope)));
+    }
+}

--- a/Tests/BacnetClientRemoteScopeConventionTests.cs
+++ b/Tests/BacnetClientRemoteScopeConventionTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -77,11 +76,20 @@ public class BacnetClientRemoteScopeConventionTests
         }
     }
 
-    private static string ClientSourcePath([CallerFilePath] string testFile = "")
+    /// <summary>
+    /// The source file, found by walking up from the test output directory (Tests/bin/...). Not
+    /// through [CallerFilePath]: a ContinuousIntegrationBuild maps source paths to /_/.
+    /// </summary>
+    private static string ClientSourcePath()
     {
-        var path = Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(testFile)), "BACnetClient.cs");
-        Assert.True(File.Exists(path), $"BACnetClient.cs not found next to the Tests folder: {path}");
-        return path;
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory); directory != null; directory = directory.Parent)
+        {
+            var candidate = Path.Combine(directory.FullName, "BACnetClient.cs");
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        throw new FileNotFoundException($"BACnetClient.cs not found above the test output directory {AppContext.BaseDirectory}");
     }
 
     private sealed record Member(string Name, string Signature, string Body, string FirstStatement);

--- a/Tests/BacnetClientRemoteScopeConventionTests.cs
+++ b/Tests/BacnetClientRemoteScopeConventionTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Guards the convention behind <c>BacnetClient.BeginRemoteScope</c>: every method that talks to a
+/// remote device - it logs "Sending ..." or "Broadcasting ..." and takes the address of the device -
+/// opens the scope as its first statement, and so does the receive entry point. A source generator
+/// cannot inject a statement into a method body, so the convention is checked against the source
+/// here instead: forgetting the scope in a new method fails this test rather than silently logging
+/// that device's traffic without its address.
+/// </summary>
+public class BacnetClientRemoteScopeConventionTests
+{
+    private const string ScopeStatement = "using var remoteScope = BeginRemoteScope(";
+
+    // a member declaration of the class: 4-space indent, access modifier, a parameter list
+    private static readonly Regex MemberSignature = new(@"^    (?:public|private|protected|internal) [^;=]*\(", RegexOptions.Compiled);
+    private static readonly Regex MemberName = new(@"(\w+)\s*\(", RegexOptions.Compiled);
+
+    // the address of the remote device - a "source" parameter is the address the frame is sent from
+    private static readonly Regex RemoteAddressParameter = new(@"BacnetAddress\s+(?:receiver|adr|address|remoteAddress)\b", RegexOptions.Compiled);
+    private static readonly Regex SendingLog = new(@"Log\.LogDebug\(\$?""(?:Sending|Broadcasting)", RegexOptions.Compiled);
+
+    [Fact]
+    public void Every_method_talking_to_a_remote_device_opens_its_scope_first()
+    {
+        var members = Members(File.ReadAllLines(ClientSourcePath())).ToList();
+
+        var talking = members
+            .Where(m => m.Name == "OnRecieve" || SendingLog.IsMatch(m.Body) && RemoteAddressParameter.IsMatch(m.Signature))
+            .ToList();
+
+        // the scan has to keep finding the methods, or a formatting change would silently disarm it
+        Assert.Contains(talking, m => m.Name == "OnRecieve");
+        Assert.Contains(talking, m => m.Name == "BeginReadPropertyRequest");
+        Assert.True(talking.Count >= 30, $"only {talking.Count} methods found - has the formatting of BACnetClient.cs changed?");
+
+        var missing = talking
+            .Where(m => !m.FirstStatement.StartsWith(ScopeStatement, StringComparison.Ordinal))
+            .Select(m => m.Name)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            $"Methods talking to a remote device without '{ScopeStatement}...)' as their first statement: {string.Join(", ", missing)}");
+    }
+
+    private static IEnumerable<Member> Members(string[] lines)
+    {
+        var starts = Enumerable.Range(0, lines.Length)
+            .Where(i => MemberSignature.IsMatch(lines[i]) && !lines[i].TrimEnd().EndsWith(";"))
+            .ToList();
+
+        for (var k = 0; k < starts.Count; k++)
+        {
+            var start = starts[k];
+            var end = k + 1 < starts.Count ? starts[k + 1] - 1 : lines.Length - 1;
+
+            // the opening brace of the body sits alone on a line at the indentation of the member;
+            // expression-bodied members have none and cannot talk to a device
+            var brace = Enumerable.Range(start, end - start + 1).FirstOrDefault(i => lines[i].TrimEnd() == "    {", -1);
+            if (brace < 0)
+                continue;
+
+            var signature = string.Join(" ", lines.Skip(start).Take(brace - start));
+            var body = lines.Skip(brace + 1).Take(end - brace).ToList();
+
+            yield return new Member(
+                MemberName.Match(signature).Groups[1].Value,
+                signature,
+                string.Join("\n", body),
+                body.Select(l => l.Trim()).FirstOrDefault(l => l.Length > 0) ?? "");
+        }
+    }
+
+    private static string ClientSourcePath([CallerFilePath] string testFile = "")
+    {
+        var path = Path.Combine(Path.GetDirectoryName(Path.GetDirectoryName(testFile)), "BACnetClient.cs");
+        Assert.True(File.Exists(path), $"BACnetClient.cs not found next to the Tests folder: {path}");
+        return path;
+    }
+
+    private sealed record Member(string Name, string Signature, string Body, string FirstStatement);
+}

--- a/Tests/Support/RecordingLogger.cs
+++ b/Tests/Support/RecordingLogger.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+
+namespace System.IO.BACnet.Tests.Support;
+
+/// <summary>
+/// Captures every entry written through it together with the scopes that were active at the time.
+/// The test transports deliver frames synchronously, so a plain scope stack is enough.
+/// </summary>
+internal sealed class RecordingLogger : ILogger
+{
+    private readonly List<object> _scopes = [];
+
+    public List<(string Message, object[] Scopes)> Entries { get; } = [];
+
+    public IDisposable BeginScope<TState>(TState state)
+    {
+        _scopes.Add(state);
+        return new Scope(this, state);
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception,
+        Func<TState, Exception, string> formatter)
+    {
+        Entries.Add((formatter(state, exception), _scopes.ToArray()));
+    }
+
+    /// <summary>The single entry whose message starts with <paramref name="prefix"/>.</summary>
+    public (string Message, object[] Scopes) Entry(string prefix)
+    {
+        return Entries.Single(e => e.Message.StartsWith(prefix, StringComparison.Ordinal));
+    }
+
+    /// <summary>The RemoteAddress property of a scope, the way a structured sink would read it.</summary>
+    public static BacnetAddress RemoteAddress(object scope)
+    {
+        return (scope as IEnumerable<KeyValuePair<string, object>>)
+            ?.FirstOrDefault(property => property.Key == "RemoteAddress").Value as BacnetAddress;
+    }
+
+    private sealed class Scope(RecordingLogger logger, object state) : IDisposable
+    {
+        public void Dispose() => logger._scopes.Remove(state);
+    }
+}


### PR DESCRIPTION
## Problem

A `BacnetClient` that talks to several devices logs all of their traffic through its single `Log`. A sink sees `Sending WritePropertyRequest OBJECT_LIFE_SAFETY_POINT:243 PROP_MODE` or `Received SimpleAck for SERVICE_CONFIRMED_WRITE_PROPERTY` with no way to tell which device the entry is about - the address is a parameter of every one of those methods, but it never reaches the log.

## Change

Every method that sends a request or a response now runs inside `Log.BeginScope("{RemoteAddress}", address)`, and so does the processing of every received frame (`OnRecieve`), which also covers the responses sent from the request handlers. Sites without a remote device are left alone: broadcasts (`receiver == null`) and the BBMD calls (`RegisterAsForeignDevice`, `RemoteWhoIs`).

The scope state is MEL's standard message-template scope with a single `RemoteAddress` property - no new public types:
- structured sinks (Serilog, NLog, ...) get it as a property,
- text sinks print it with `IncludeScopes` (`10.0.0.2:47808 Sending ReadPropertyRequest ...`),
- a sink can use it to route each device's traffic to its own log,
- sinks that ignore scopes see no change; with the default `NullLogger` the scope is a no-op.

One private helper (`BeginRemoteScope`) and one `using var` line per method; no behaviour change otherwise.

## Keeping the convention

A source generator cannot inject a statement into an existing method body, so the scope stays an explicit first line. `BacnetClientRemoteScopeConventionTests` scans `BACnetClient.cs` for every method that talks to a remote device (logs `Sending ...`/`Broadcasting ...` and takes the device's address) plus `OnRecieve`, and fails with the names of the ones that do not open the scope first - a new request method cannot forget it unnoticed. Verified by deleting one scope line: the test fails naming `BeginWritePropertyRequest`.

## Tests

`BacnetClientLogScopeTests` with a scope-recording logger: confirmed requests carry the device address (and the scope renders as the address), unconfirmed requests carry the receiver, broadcasts carry no scope, and over the loopback transport a server logs the request and its response within the requester's scope while the client logs the ack within the responder's. 356/356 pass; the library builds for net48, netstandard2.0, net8.0 and net10.0 with no new warnings.

`CHANGELOG.md` (Unreleased / Added) updated.

