### PR TITLE
fix: key segmentation state per device, not per invoke-id

### DIFF
--- a/BACnetClient.cs
+++ b/BACnetClient.cs
@@ -37,16 +37,16 @@ public class BacnetClient : IDisposable
     private int _retries;
     private int _invokeId;
 
-    private readonly LastSegmentAck _lastSegmentAck = new();
     private uint _writepriority;
 
     /// <summary>
-    /// Dictionary of List of Tuples with sequence-number and byte[] per invoke-id
-    /// TODO: invoke-id should be PER (remote) DEVICE!
+    /// The segments received for a transfer, and the segment ack received for one this client is
+    /// sending. Both are keyed by the transfer rather than by the invoke-id alone: an invoke-id is
+    /// unique per device (135 §20.1.2.6), so two devices talking to this client at the same time
+    /// number their transfers with the same ones.
     /// </summary>
-    private Dictionary<byte, List<Tuple<byte, byte[]>>> _segmentsPerInvokeId = new();
-    private ConcurrentDictionary<byte, object> _locksPerInvokeId = new();
-    private Dictionary<byte, byte> _expectedSegmentsPerInvokeId = new();
+    private readonly ConcurrentDictionary<TransferId, SegmentAssembly> _assemblies = new();
+    private readonly ConcurrentDictionary<TransferId, LastSegmentAck> _segmentAcks = new();
 
     public const int DEFAULT_UDP_PORT = 0xBAC0;
     public const int DEFAULT_TIMEOUT = 1000;
@@ -101,41 +101,96 @@ public class BacnetClient : IDisposable
         public BacnetMaxAdpu? RequesterMaxAdpu { get; set; }
     }
 
-    private class LastSegmentAck
+    /// <summary>
+    /// One transfer: the device it runs with and the invoke-id it runs under. Hashed on the
+    /// invoke-id alone - an address without a MAC has no usable hash code, and the few devices that
+    /// share an invoke-id are nothing for a single bucket.
+    /// </summary>
+    private readonly struct TransferId : IEquatable<TransferId>
     {
-        private readonly ManualResetEvent _wait = new(false);
+        private readonly BacnetAddress _device;
+        private readonly byte _invokeId;
+
+        public TransferId(BacnetAddress device, byte invokeId)
+        {
+            _device = device;
+            _invokeId = invokeId;
+        }
+
+        public bool Equals(TransferId other)
+        {
+            return _invokeId == other._invokeId && (_device?.Equals(other._device) ?? other._device == null);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is TransferId other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return _invokeId;
+        }
+    }
+
+    /// <summary>
+    /// The segments received so far for one transfer. <see cref="Lock"/> guards them: frames are
+    /// processed concurrently (the IP transport re-arms its receive before handling the datagram it
+    /// took), so the segments of a transfer can arrive on different threads.
+    /// </summary>
+    private sealed class SegmentAssembly
+    {
+        public readonly object Lock = new();
+        public readonly List<Tuple<byte, byte[]>> Segments = new();
+        public byte ExpectedSegments = byte.MaxValue;
+    }
+
+    /// <summary>
+    /// The last segment ack received for one transfer: the sequence number the device acknowledged
+    /// and the window size it granted. One instance per transfer - a single slot for the whole
+    /// client let the ack of one device overwrite the ack of another before the thread sending to
+    /// that other device had read it.
+    /// </summary>
+    private sealed class LastSegmentAck
+    {
         private readonly object _lockObject = new();
-        private BacnetAddress _address;
-        private byte _invokeId;
+        private bool _received;
+        private byte _sequenceNumber;
+        private byte _windowSize;
 
-        public byte SequenceNumber;
-        public byte WindowSize;
-
-        public void Set(BacnetAddress adr, byte invokeId, byte sequenceNumber, byte windowSize)
+        public void Set(byte sequenceNumber, byte windowSize)
         {
             lock (_lockObject)
             {
-                _address = adr;
-                _invokeId = invokeId;
-                SequenceNumber = sequenceNumber;
-                WindowSize = windowSize;
-                _wait.Set();
+                _sequenceNumber = sequenceNumber;
+                _windowSize = windowSize;
+                _received = true;
+                Monitor.PulseAll(_lockObject);
             }
         }
 
-        public bool Wait(BacnetAddress adr, byte invokeId, int timeout)
+        /// <summary>
+        /// Takes the ack out, waiting up to <paramref name="timeout"/> for one to arrive. The values
+        /// leave under the lock: the ack of the next window must not overwrite them between the wait
+        /// and the reading. Waited for with a monitor rather than an event, so that keeping an
+        /// instance per transfer costs an object and no operating system handle.
+        /// </summary>
+        public bool Wait(int timeout, out byte sequenceNumber, out byte windowSize)
         {
-            Monitor.Enter(_lockObject);
-            while (!adr.Equals(this._address) || this._invokeId != invokeId)
+            lock (_lockObject)
             {
-                _wait.Reset();
-                Monitor.Exit(_lockObject);
-                if (!_wait.WaitOne(timeout)) return false;
-                Monitor.Enter(_lockObject);
+                if (!_received && !Monitor.Wait(_lockObject, timeout))
+                {
+                    sequenceNumber = 0;
+                    windowSize = 0;
+                    return false;
+                }
+
+                _received = false;
+                sequenceNumber = _sequenceNumber;
+                windowSize = _windowSize;
+                return true;
             }
-            Monitor.Exit(_lockObject);
-            _address = null;
-            return true;
         }
     }
 
@@ -737,29 +792,27 @@ public class BacnetClient : IDisposable
 
     private void ProcessSegment(BacnetAddress address, BacnetPduTypes type, BacnetConfirmedServices service, byte invokeId, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, bool server, byte sequenceNumber, byte proposedWindowNumber, byte[] buffer, int offset, int length)
     {
-        lock (_locksPerInvokeId.GetOrAdd(invokeId, () => new object()))
+        var transfer = new TransferId(address, invokeId);
+        var assembly = _assemblies.GetOrAdd(transfer, _ => new SegmentAssembly());
+
+        lock (assembly.Lock)
         {
-            ProcessSegmentLocked(address, type, service, invokeId, maxSegments, maxAdpu, server, sequenceNumber,
-                proposedWindowNumber, buffer, offset, length);
+            ProcessSegmentLocked(transfer, assembly, address, type, service, invokeId, maxSegments, maxAdpu, server,
+                sequenceNumber, proposedWindowNumber, buffer, offset, length);
         }
     }
 
-    private void ProcessSegmentLocked(BacnetAddress adr, BacnetPduTypes type, BacnetConfirmedServices service,
-        byte invokeId, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, bool server, byte sequenceNumber,
-        byte proposedWindowNumber, byte[] buffer, int offset, int length)
+    private void ProcessSegmentLocked(TransferId transfer, SegmentAssembly assembly, BacnetAddress adr,
+        BacnetPduTypes type, BacnetConfirmedServices service, byte invokeId, BacnetMaxSegments maxSegments,
+        BacnetMaxAdpu maxAdpu, bool server, byte sequenceNumber, byte proposedWindowNumber, byte[] buffer, int offset,
+        int length)
     {
         Log.LogTrace($@"Processing Segment #{sequenceNumber} of invoke-id #{invokeId}");
-
-        if (!_segmentsPerInvokeId.ContainsKey(invokeId))
-            _segmentsPerInvokeId[invokeId] = new List<Tuple<byte, byte[]>>();
-
-        if (!_expectedSegmentsPerInvokeId.ContainsKey(invokeId))
-            _expectedSegmentsPerInvokeId[invokeId] = byte.MaxValue;
 
         var moreFollows = (type & BacnetPduTypes.MORE_FOLLOWS) == BacnetPduTypes.MORE_FOLLOWS;
 
         if (!moreFollows)
-            _expectedSegmentsPerInvokeId[invokeId] = (byte)(sequenceNumber + 1);
+            assembly.ExpectedSegments = (byte)(sequenceNumber + 1);
 
         //send ACK
         if (sequenceNumber % proposedWindowNumber == 0 || !moreFollows)
@@ -775,15 +828,15 @@ public class BacnetClient : IDisposable
 
         //default segment assembly. We run this seperately from the above handler, to make sure that it comes after!
         if (DefaultSegmentationHandling)
-            PerformDefaultSegmentHandling(adr, type, service, invokeId, maxSegments, maxAdpu, sequenceNumber, buffer, offset, length);
+            PerformDefaultSegmentHandling(transfer, assembly, adr, type, service, invokeId, maxSegments, maxAdpu, sequenceNumber, buffer, offset, length);
     }
 
     /// <summary>
     /// This is a simple handling that stores all segments in memory and assembles them when done
     /// </summary>
-    private void PerformDefaultSegmentHandling(BacnetAddress adr, BacnetPduTypes type, BacnetConfirmedServices service, byte invokeId, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, byte sequenceNumber, byte[] buffer, int offset, int length)
+    private void PerformDefaultSegmentHandling(TransferId transfer, SegmentAssembly assembly, BacnetAddress adr, BacnetPduTypes type, BacnetConfirmedServices service, byte invokeId, BacnetMaxSegments maxSegments, BacnetMaxAdpu maxAdpu, byte sequenceNumber, byte[] buffer, int offset, int length)
     {
-        var segments = _segmentsPerInvokeId[invokeId];
+        var segments = assembly.Segments;
 
         if (sequenceNumber == 0)
         {
@@ -810,13 +863,15 @@ public class BacnetClient : IDisposable
         }
 
         //process when finished
-        if (segments.Count < _expectedSegmentsPerInvokeId[invokeId])
+        if (segments.Count < assembly.ExpectedSegments)
             return;
 
         //assemble whole part
         var apduBuffer = segments.OrderBy(s => s.Item1).SelectMany(s => s.Item2).ToArray();
-        segments.Clear();
-        _expectedSegmentsPerInvokeId[invokeId] = byte.MaxValue;
+
+        // the transfer is over: drop its state instead of leaving an entry per invoke-id per device
+        // behind. A segment arriving late starts a new one, as it did with the cleared list before.
+        _assemblies.TryRemove(transfer, out _);
 
         //process
         ProcessApdu(adr, type, apduBuffer, 0, apduBuffer.Length);
@@ -870,7 +925,8 @@ public class BacnetClient : IDisposable
 
                     offset += apduHeaderLen;
                     length -= apduHeaderLen;
-                    _lastSegmentAck.Set(adr, originalInvokeId, sequenceNumber, actualWindowSize);
+                    _segmentAcks.GetOrAdd(new TransferId(adr, originalInvokeId), _ => new LastSegmentAck())
+                        .Set(sequenceNumber, actualWindowSize);
                     ProcessSegmentAck(adr, type, originalInvokeId, sequenceNumber, actualWindowSize, buffer, offset, length);
                 }
                 break;
@@ -3568,11 +3624,17 @@ public class BacnetClient : IDisposable
 
     public bool WaitForSegmentAck(BacnetAddress adr, byte invokeId, Segmentation segmentation, int timeout)
     {
-        if (!_lastSegmentAck.Wait(adr, invokeId, timeout))
-            return false;
+        var transfer = new TransferId(adr, invokeId);
 
-        segmentation.sequence_number = (byte)((_lastSegmentAck.SequenceNumber + 1) % 256);
-        segmentation.window_size = _lastSegmentAck.WindowSize;
+        if (!_segmentAcks.GetOrAdd(transfer, _ => new LastSegmentAck()).Wait(timeout, out var sequenceNumber, out var windowSize))
+        {
+            // nothing is going to consume an ack of a transfer that gave up waiting for one
+            _segmentAcks.TryRemove(transfer, out _);
+            return false;
+        }
+
+        segmentation.sequence_number = (byte)((sequenceNumber + 1) % 256);
+        segmentation.window_size = windowSize;
         return true;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to this project are documented here. The format is based on
   remote device and get no scope. Sinks that ignore scopes see no change.
 
 ### Fixed
+- **Segmentation** state is kept per transfer - the remote device plus the invoke-id - instead of per
+  invoke-id alone. An invoke-id is unique per device (135 §20.1.2.6), so two devices answering at the
+  same time both number a transfer 1: the segments of one were assembled into the transfer of the
+  other, and the single segment-ack slot let the ack of one device discard the ack of another. Every
+  transfer has a lock of its own now, which concurrently processed frames need - the IP transport
+  re-arms its receive before it handles the datagram it just took.
 - SIGNED_INT property values serialize with the invariant culture, like the other numeric tags. They
   fell through to the default branch of `Property.SerializeValue` and used the current culture, so a
   host whose culture spells the negative sign U+2212 (sv-SE and friends, under ICU) wrote `−5` into

--- a/Tests/BacnetClientConcurrentSegmentationTests.cs
+++ b/Tests/BacnetClientConcurrentSegmentationTests.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using System.IO.BACnet.Serialize;
+using System.IO.BACnet.Tests.Support;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.BACnet.Tests;
+
+/// <summary>
+/// Segmentation state belongs to a transfer, and a transfer is a device plus the invoke-id that
+/// device chose: two panels numbering their own traffic independently both send an invoke-id 1, and
+/// frames are processed concurrently (the UDP transport re-arms its receive before handling the
+/// datagram it just took), so state keyed by the invoke-id alone mixes the segments of one device
+/// into the transfer of another, and a single segment-ack slot lets the ack of one device discard
+/// the ack of another.
+/// </summary>
+public class BacnetClientConcurrentSegmentationTests
+{
+    private const BacnetConfirmedServices Service = BacnetConfirmedServices.SERVICE_CONFIRMED_READ_PROPERTY;
+
+    private static BacnetAddress Device(int index) => new(BacnetAddressTypes.IP, $"10.0.0.{index}:47808");
+
+    /// <summary>A segment of a ComplexACK: [type][invoke-id][sequence][window][service] payload.</summary>
+    private static byte[] Segment(byte invokeId, byte sequenceNumber, bool moreFollows, params byte[] payload)
+    {
+        var type = BacnetPduTypes.PDU_TYPE_COMPLEX_ACK | BacnetPduTypes.SEGMENTED_MESSAGE |
+                   (moreFollows ? BacnetPduTypes.MORE_FOLLOWS : 0);
+
+        var buffer = new EncodeBuffer(new byte[payload.Length + 16], 0);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, null);
+        APDU.EncodeComplexAck(buffer, type, Service, invokeId, sequenceNumber, 1);
+        buffer.Add(payload, payload.Length);
+        return buffer.ToArray();
+    }
+
+    private static byte[] SegmentAck(byte invokeId, byte sequenceNumber, byte windowSize)
+    {
+        var buffer = new EncodeBuffer(new byte[16], 0);
+        NPDU.Encode(buffer, BacnetNpduControls.PriorityNormalMessage, null);
+        APDU.EncodeSegmentAck(buffer, BacnetPduTypes.PDU_TYPE_SEGMENT_ACK, invokeId, sequenceNumber, windowSize);
+        return buffer.ToArray();
+    }
+
+    /// <summary>The payload of every ComplexACK the client assembled, in arrival order.</summary>
+    private static List<byte[]> RecordAssembled(BacnetClient client)
+    {
+        var assembled = new List<byte[]>();
+
+        client.OnComplexAck += (sender, adr, type, service, invokeId, buffer, offset, length) =>
+        {
+            lock (assembled)
+                assembled.Add(buffer.Skip(offset).Take(length).ToArray());
+        };
+
+        return assembled;
+    }
+
+    [Fact]
+    public void Two_devices_can_run_a_segmented_transfer_with_the_same_invoke_id()
+    {
+        var transport = new RecordingTransport();
+        using var client = new BacnetClient(transport);
+        client.Start();
+        var assembled = RecordAssembled(client);
+
+        // both devices answer with invoke-id 1, interleaved, two segments each
+        transport.Receive(Segment(1, 0, true, 0xA0), Device(2));
+        transport.Receive(Segment(1, 0, true, 0xB0), Device(3));
+        transport.Receive(Segment(1, 1, false, 0xA1), Device(2));
+        transport.Receive(Segment(1, 1, false, 0xB1), Device(3));
+
+        Assert.Equal(2, assembled.Count);
+        Assert.Contains(assembled, payload => payload.SequenceEqual(new byte[] { 0xA0, 0xA1 }));
+        Assert.Contains(assembled, payload => payload.SequenceEqual(new byte[] { 0xB0, 0xB1 }));
+    }
+
+    [Fact]
+    public void Segmented_transfers_of_several_devices_assemble_while_they_run_in_parallel()
+    {
+        const int devices = 4;
+        const int transfersPerDevice = 25;
+
+        var transport = new RecordingTransport();
+        using var client = new BacnetClient(transport);
+        client.Start();
+        var assembled = RecordAssembled(client);
+
+        Parallel.For(0, devices, device =>
+        {
+            for (var transfer = 0; transfer < transfersPerDevice; transfer++)
+            {
+                // every device numbers its own transfers, so they all use invoke-id 1
+                transport.Receive(Segment(1, 0, true, (byte)device, (byte)transfer), Device(device + 2));
+                transport.Receive(Segment(1, 1, false, (byte)device, (byte)transfer), Device(device + 2));
+            }
+        });
+
+        var expected = Enumerable.Range(0, devices).SelectMany(device =>
+            Enumerable.Range(0, transfersPerDevice).Select(transfer =>
+                new byte[] { (byte)device, (byte)transfer, (byte)device, (byte)transfer }));
+
+        Assert.Equal(devices * transfersPerDevice, assembled.Count);
+        Assert.All(expected, payload => Assert.Contains(assembled, a => a.SequenceEqual(payload)));
+    }
+
+    [Fact]
+    public void The_segment_ack_of_one_device_does_not_discard_the_ack_of_another()
+    {
+        var transport = new RecordingTransport();
+        using var client = new BacnetClient(transport);
+        client.Start();
+
+        // both acks arrive before the sending threads get to wait for them
+        transport.Receive(SegmentAck(2, 5, 1), Device(3));
+        transport.Receive(SegmentAck(1, 0, 1), Device(2));
+
+        var deviceB = new BacnetClient.Segmentation();
+        Assert.True(client.WaitForSegmentAck(Device(3), 2, deviceB, 200), "the segment ack of device B was lost");
+        Assert.Equal(6, deviceB.sequence_number);
+        Assert.Equal(1, deviceB.window_size);
+
+        var deviceA = new BacnetClient.Segmentation();
+        Assert.True(client.WaitForSegmentAck(Device(2), 1, deviceA, 200), "the segment ack of device A was lost");
+        Assert.Equal(1, deviceA.sequence_number);
+    }
+}


### PR DESCRIPTION
`_segmentsPerInvokeId` and the single `_lastSegmentAck` were keyed by invoke-id alone, but an
invoke-id is unique per device (135 §20.1.2.6): two devices answering at the same time both use
invoke-id 1. So the segments of one transfer landed in another's, and one device's segment ack
discarded the other's. Both now live per transfer - device plus invoke-id - each with its own lock,
which frames need because they are processed concurrently: the IP transport re-arms its receive
before handling the datagram it just took.

`Tests/BacnetClientConcurrentSegmentationTests.cs` covers the three cases. Against `v4` they fail
(1 of 2 transfers assembled, 95 of 100 under parallel load, segment ack lost); with the fix the
suite is green.
